### PR TITLE
Feat: Cinematic Post-Processing & Sequencer Integration

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -42,6 +42,9 @@
 ### Phase 6: Structural Dynamics
 - [x] **Dendritic Growth Animation:** Implement `growth` uniform to control the maximum render radius of the brain structure, simulating organic growth.
 
+### Phase 7: Cinematic Post-Processing
+- [x] **Chromatic Aberration & Film Grain:** Implement a post-processing pipeline for cinematic effects (RGB split, noise).
+
 ---
 
 ## 🧪 "Dream" Log (Future Concepts)

--- a/brain-renderer.js
+++ b/brain-renderer.js
@@ -1,7 +1,7 @@
 // brain-renderer.js
 // Verified Neuro-Weaver V2.6 Implementation
 import { BrainGeometry } from './brain-geometry.js';
-import { vertexShader, fragmentShader, computeShader, somaVertexShader, somaFragmentShader } from './shaders.js';
+import { vertexShader, fragmentShader, computeShader, somaVertexShader, somaFragmentShader, postVertexShader, postFragmentShader } from './shaders.js';
 import { Mat4 } from './math-utils.js';
 
 export class BrainRenderer {
@@ -13,7 +13,8 @@ export class BrainRenderer {
         // Pipelines
         this.pipeline = null;      // Solid Mesh
         this.fiberPipeline = null; // Lines
-        this.somaPipeline = null;  // Instanced Spheres (Somas) [Renamed for V2.6]
+        this.somaPipeline = null;  // Instanced Spheres (Somas)
+        this.postPipeline = null;  // [Phase 7] Cinematic Post-Process
         
         this.rotation = { x: 0, y: 0 };
         this.targetRotation = { x: 0.3, y: 0 };
@@ -33,7 +34,9 @@ export class BrainRenderer {
             colorShift: 0.0, // [Phase 5] Serotonin Color Shift
             sparkle: 0.0, // [Phase 5] Synaptic Sparkles
             growth: 1.0, // [Phase 6] Dendritic Growth (0.0 - 1.0)
-            shake: 0.0 // [Phase 2] Camera Shake Intensity (Trauma/Panic)
+            shake: 0.0, // [Phase 2] Camera Shake Intensity (Trauma/Panic)
+            aberration: 0.0, // [Phase 7] Chromatic Aberration Intensity
+            grain: 0.0 // [Phase 7] Film Grain Intensity
         };
 
         // Voxel Grid Settings
@@ -48,6 +51,10 @@ export class BrainRenderer {
             active: 0.0
         };
         
+        this.renderTarget = null;
+        this.sampler = null;
+        this.postBindGroup = null;
+
         this.setupInputHandlers();
     }
     
@@ -183,12 +190,16 @@ export class BrainRenderer {
         this.initSomaPipeline(renderBindGroupLayout, format);
         this.initComputePipeline();
 
+        // [Phase 7] Post-Processing Init
+        this.initPostProcessing(format);
+
         // Ensure canvas dimensions are valid before creating depth texture
         const width = Math.max(1, this.canvas.width);
         const height = Math.max(1, this.canvas.height);
         this.depthTexture = this.device.createTexture({ size: [width, height], format: 'depth24plus', usage: GPUTextureUsage.RENDER_ATTACHMENT });
+        this.createRenderTarget(width, height);
 
-        console.log("Renderer V2.6 Verified");
+        console.log("Renderer V2.6 Verified with Post-Processing");
     }
 
     // [Neuro-Weaver] Refactored: Initialize Volumetric Data (Tensor)
@@ -301,6 +312,55 @@ export class BrainRenderer {
         });
     }
 
+    // [Phase 7] Initialize Post-Processing
+    initPostProcessing(format) {
+        const postModule = this.device.createShaderModule({ code: postVertexShader });
+        const postFragModule = this.device.createShaderModule({ code: postFragmentShader });
+
+        this.postPipeline = this.device.createRenderPipeline({
+            layout: 'auto',
+            vertex: {
+                module: postModule,
+                entryPoint: 'main'
+            },
+            fragment: {
+                module: postFragModule,
+                entryPoint: 'main',
+                targets: [{ format: format }] // Render to screen
+            },
+            primitive: {
+                topology: 'triangle-list'
+            }
+        });
+
+        this.sampler = this.device.createSampler({
+            magFilter: 'linear',
+            minFilter: 'linear',
+        });
+    }
+
+    createRenderTarget(width, height) {
+        if (this.renderTarget) this.renderTarget.destroy();
+
+        // Must match canvas format for compatibility if copying, but here we render to it then sample from it.
+        // It's used as a color attachment and a texture binding.
+        this.renderTarget = this.device.createTexture({
+            size: [width, height],
+            format: navigator.gpu.getPreferredCanvasFormat(),
+            usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING
+        });
+
+        // Recreate Bind Group
+        this.postBindGroup = this.device.createBindGroup({
+            layout: this.postPipeline.getBindGroupLayout(0),
+            entries: [
+                { binding: 0, resource: { buffer: this.uniformBuffer } },
+                { binding: 1, resource: this.renderTarget.createView() },
+                { binding: 2, resource: this.sampler }
+            ]
+        });
+    }
+
     createBuffer(data, usage) {
         const buffer = this.device.createBuffer({ size: data.byteLength, usage: usage | GPUBufferUsage.COPY_DST });
         this.device.queue.writeBuffer(buffer, 0, data);
@@ -345,6 +405,8 @@ export class BrainRenderer {
         this.params.smoothing = 0.98;
         this.params.colorShift = 0.0;
         this.params.sparkle = 0.0;
+        this.params.aberration = 0.0;
+        this.params.grain = 0.0;
     }
 
     resetActivity() {
@@ -384,6 +446,9 @@ export class BrainRenderer {
         // [35]: ColorShift
         // [36-39]: SlicePlane (Vec4, 16 bytes)
         // [40]: Sparkle (4 bytes)
+        // [41]: Growth (4 bytes)
+        // [42]: Aberration (4 bytes)
+        // [43]: Grain (4 bytes)
 
         const OFFSET_MVP = 0;
         const OFFSET_MODEL = 16;
@@ -394,6 +459,8 @@ export class BrainRenderer {
         const OFFSET_SLICE = 36;
         const OFFSET_SPARKLE = 40;
         const OFFSET_GROWTH = 41;
+        const OFFSET_ABERRATION = 42;
+        const OFFSET_GRAIN = 43;
 
         const uData = new Float32Array(48); // 48 * 4 = 192 bytes
         uData.set(mvp, OFFSET_MVP);
@@ -411,6 +478,8 @@ export class BrainRenderer {
 
         uData[OFFSET_SPARKLE] = this.params.sparkle;
         uData[OFFSET_GROWTH] = this.params.growth;
+        uData[OFFSET_ABERRATION] = this.params.aberration;
+        uData[OFFSET_GRAIN] = this.params.grain;
 
         this.device.queue.writeBuffer(this.uniformBuffer, 0, uData);
         
@@ -457,6 +526,9 @@ export class BrainRenderer {
             this.canvas.width = width; this.canvas.height = height;
             this.depthTexture.destroy();
             this.depthTexture = this.device.createTexture({ size: [width, height], format: 'depth24plus', usage: GPUTextureUsage.RENDER_ATTACHMENT });
+
+            // Resize Render Target
+            this.createRenderTarget(width, height);
         }
 
         this.time += 0.016;
@@ -470,9 +542,10 @@ export class BrainRenderer {
         computePass.dispatchWorkgroups(Math.ceil(this.voxelBufferSize / 64));
         computePass.end();
         
+        // --- PASS 1: RENDER SCENE TO TEXTURE ---
         const renderPass = commandEncoder.beginRenderPass({
             colorAttachments: [{
-                view: this.context.getCurrentTexture().createView(),
+                view: this.renderTarget.createView(),
                 clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 }, 
                 loadOp: 'clear', storeOp: 'store'
             }],
@@ -507,6 +580,21 @@ export class BrainRenderer {
         }
         
         renderPass.end();
+
+        // --- PASS 2: POST-PROCESSING TO SCREEN ---
+        const postPass = commandEncoder.beginRenderPass({
+            colorAttachments: [{
+                view: this.context.getCurrentTexture().createView(),
+                loadOp: 'clear', storeOp: 'store',
+                clearValue: { r: 0, g: 0, b: 0, a: 1 }
+            }]
+        });
+
+        postPass.setPipeline(this.postPipeline);
+        postPass.setBindGroup(0, this.postBindGroup);
+        postPass.draw(6); // Draw full-screen quad
+        postPass.end();
+
         this.device.queue.submit([commandEncoder.finish()]);
         requestAnimationFrame(() => this.render());
     }

--- a/index.html
+++ b/index.html
@@ -86,6 +86,16 @@
             <input type="range" id="shake" min="0.0" max="0.5" step="0.01" value="0.0">
         </div>
 
+        <div class="control-group">
+            <label>Chromatic Aberration <span id="val-aberration" class="value">0.0</span></label>
+            <input type="range" id="aberration" min="0.0" max="2.0" step="0.01" value="0.0">
+        </div>
+
+        <div class="control-group">
+            <label>Film Grain <span id="val-grain" class="value">0.0</span></label>
+            <input type="range" id="grain" min="0.0" max="1.0" step="0.01" value="0.0">
+        </div>
+
         <hr>
 
         <div class="control-group">

--- a/main.js
+++ b/main.js
@@ -46,6 +46,8 @@ const MINI_ROUTINES = {
         { time: 0.0, type: 'text', message: 'PANIC!', duration: 1.0 },
         { time: 0.0, type: 'style', value: 1 }, // Cyber/Glitch
         { time: 0.0, type: 'shake', intensity: 0.1, duration: 4.0 }, // Big shake
+        { time: 0.0, type: 'cinematic', aberration: 1.0, duration: 0.2 }, // [Phase 7] Aberration spike
+        { time: 0.0, type: 'cinematic', grain: 0.8, duration: 0.5 }, // [Phase 7] Grain spike
         { time: 0.0, type: 'lerp', key: 'frequency', value: 15.0, duration: 0.5 },
         { time: 0.0, type: 'lerp', key: 'flowSpeed', value: 20.0, duration: 0.5 },
         { time: 0.5, type: 'lerp', key: 'colorShift', value: 1.0, duration: 0.1 }, // Flash Red
@@ -53,6 +55,7 @@ const MINI_ROUTINES = {
         { time: 0.7, type: 'lerp', key: 'colorShift', value: 1.0, duration: 0.1 },
         { time: 0.8, type: 'lerp', key: 'colorShift', value: 0.0, duration: 0.1 },
         { time: 1.0, type: 'stimulus', target: 'deep', intensity: 5.0 },
+        { time: 2.0, type: 'cinematic', aberration: 0.0, grain: 0.0, duration: 2.0 },
         { time: 4.0, type: 'calm' },
         { time: 4.0, type: 'text', message: 'Stabilizing...', duration: 2.0 }
     ]
@@ -74,6 +77,8 @@ async function init() {
         sparkle: document.getElementById('sparkle'), // [Phase 5]
         growth: document.getElementById('growth'), // [Phase 6]
         shake: document.getElementById('shake'), // [Phase 2]
+        aberration: document.getElementById('aberration'), // [Phase 7]
+        grain: document.getElementById('grain'), // [Phase 7]
         style: document.getElementById('style-mode')
     };
     
@@ -87,7 +92,9 @@ async function init() {
         colorShift: document.getElementById('val-shift'), // [Phase 5]
         sparkle: document.getElementById('val-sparkle'), // [Phase 5]
         growth: document.getElementById('val-growth'), // [Phase 6]
-        shake: document.getElementById('val-shake') // [Phase 2]
+        shake: document.getElementById('val-shake'), // [Phase 2]
+        aberration: document.getElementById('val-aberration'), // [Phase 7]
+        grain: document.getElementById('val-grain') // [Phase 7]
     };
     
     if (!navigator.gpu) {
@@ -202,7 +209,7 @@ async function init() {
              if (event.type === 'calm') {
                  // Calm state modifies amplitude, frequency, smoothing
                  // We should sync them if they are in the renderer params
-                 ['amplitude', 'frequency', 'smoothing', 'colorShift', 'sparkle', 'shake'].forEach(k => {
+                 ['amplitude', 'frequency', 'smoothing', 'colorShift', 'sparkle', 'shake', 'aberration', 'grain'].forEach(k => {
                     if (inputs[k]) inputs[k].value = renderer.params[k];
                     if (labels[k]) labels[k].textContent = renderer.params[k].toFixed(2);
                  });
@@ -566,7 +573,7 @@ function initUIControls(renderer, uiInputs, uiLabels) {
 
     document.getElementById('stim-calm')?.addEventListener('click', () => {
         renderer.calmState();
-        ['amplitude', 'frequency', 'smoothing', 'colorShift', 'sparkle', 'shake'].forEach(k => {
+        ['amplitude', 'frequency', 'smoothing', 'colorShift', 'sparkle', 'shake', 'aberration', 'grain'].forEach(k => {
             if(uiInputs[k]) uiInputs[k].value = renderer.params[k];
             syncParam(k, renderer.params[k]);
         });

--- a/routine-player.js
+++ b/routine-player.js
@@ -92,6 +92,24 @@ export class RoutinePlayer {
             }
         });
 
+        // [Phase 7] Cinematic Effects (Aberration, Grain)
+        this.registerHandler('cinematic', (evt) => {
+            if (evt.aberration !== undefined) {
+                if (evt.duration) {
+                    this.startLerp({ key: 'aberration', value: evt.aberration, duration: evt.duration, ease: evt.ease });
+                } else {
+                    this.renderer.setParams({ aberration: evt.aberration });
+                }
+            }
+            if (evt.grain !== undefined) {
+                 if (evt.duration) {
+                    this.startLerp({ key: 'grain', value: evt.grain, duration: evt.duration, ease: evt.ease });
+                } else {
+                    this.renderer.setParams({ grain: evt.grain });
+                }
+            }
+        });
+
         // Camera Control
         this.registerHandler('camera', (evt) => {
             this.handleCamera(evt);

--- a/shaders.js
+++ b/shaders.js
@@ -103,6 +103,8 @@ struct Uniforms {
     slicePlane: vec4<f32>, // [Neuro-Weaver] V2.6: Renamed from clipPlane
     sparkle: f32, // [Phase 5] Synaptic Sparkles
     growth: f32, // [Phase 6] Dendritic Growth
+    aberration: f32, // [Phase 7] Chromatic Aberration
+    grain: f32, // [Phase 7] Film Grain
 }
 
 struct VertexInput {
@@ -257,6 +259,8 @@ struct Uniforms {
     slicePlane: vec4<f32>, // [Neuro-Weaver] V2.6: Renamed from clipPlane
     sparkle: f32, // [Phase 5] Synaptic Sparkles
     growth: f32, // [Phase 6]
+    aberration: f32, // [Phase 7]
+    grain: f32, // [Phase 7]
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 
@@ -323,6 +327,8 @@ struct Uniforms {
     slicePlane: vec4<f32>, // [Neuro-Weaver] V2.6: Renamed from clipPlane
     sparkle: f32, // [Phase 5] Synaptic Sparkles
     growth: f32, // [Phase 6]
+    aberration: f32, // [Phase 7]
+    grain: f32, // [Phase 7]
 }
 
 struct VertexInput {
@@ -525,3 +531,62 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
     activityTensor[index] = clamp(val, 0.0, 1.0);
 }
 `;
+
+// [Phase 7] Post-Processing Shaders
+
+export const postVertexShader = \`
+@vertex
+fn main(@builtin(vertex_index) VertexIndex : u32) -> @builtin(position) vec4<f32> {
+    var pos = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0, -1.0), vec2<f32>(1.0, -1.0), vec2<f32>(-1.0, 1.0),
+        vec2<f32>(-1.0, 1.0), vec2<f32>(1.0, -1.0), vec2<f32>(1.0, 1.0)
+    );
+    return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+}
+\`;
+
+export const postFragmentShader = \`
+struct Uniforms {
+    mvpMatrix: mat4x4<f32>,
+    modelMatrix: mat4x4<f32>,
+    time: f32,
+    style: f32,
+    flowSpeed: f32,
+    colorShift: f32,
+    slicePlane: vec4<f32>,
+    sparkle: f32,
+    growth: f32,
+    aberration: f32,
+    grain: f32,
+}
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var tDiffuse: texture_2d<f32>;
+@group(0) @binding(2) var sDiffuse: sampler;
+
+@fragment
+fn main(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
+    let uv = position.xy / vec2<f32>(textureDimensions(tDiffuse));
+
+    // Chromatic Aberration
+    var offset = uniforms.aberration * 0.01;
+    // Distort from center
+    let center = vec2<f32>(0.5, 0.5);
+    let dist = distance(uv, center);
+    // Increase offset at edges
+    offset *= dist * 2.0;
+
+    let r = textureSample(tDiffuse, sDiffuse, uv + vec2<f32>(offset, 0.0)).r;
+    let g = textureSample(tDiffuse, sDiffuse, uv).g;
+    let b = textureSample(tDiffuse, sDiffuse, uv - vec2<f32>(offset, 0.0)).b;
+
+    var color = vec3<f32>(r, g, b);
+
+    // Film Grain
+    if (uniforms.grain > 0.0) {
+        let noise = fract(sin(dot(uv + uniforms.time * 0.1, vec2<f32>(12.9898, 78.233))) * 43758.5453);
+        color += (noise - 0.5) * uniforms.grain;
+    }
+
+    return vec4<f32>(color, 1.0);
+}
+\`;


### PR DESCRIPTION
Implemented a cinematic post-processing pipeline adding Chromatic Aberration and Film Grain effects to the brain visualization. This involved:
1.  **Shaders:** Added `postVertexShader` (fullscreen quad) and `postFragmentShader` (RGB split & noise) to `shaders.js`.
2.  **Renderer:** Modified `BrainRenderer` to support off-screen rendering to a texture and a second pass for post-processing.
3.  **Sequencer:** Extended `RoutinePlayer` with a `cinematic` event type to allow sequencing of these effects.
4.  **UI:** Added sliders to control aberration and grain intensity.
5.  **Routine:** Updated the "Panic Attack" routine to demonstrate the new effects.


---
*PR created automatically by Jules for task [5821680240206298315](https://jules.google.com/task/5821680240206298315) started by @ford442*