### PR TITLE
Neuro-Script Cycle: Graceful WebGPU Degradation + Recovery Telemetry

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -123,10 +123,11 @@
 ---
 ### Phase 11: Robust Expression & Hardening
 - [x] **Timeline Compensation + Catch-Up Logic:** Implement catch-up logic in the scheduler. When a long frame or async operation causes drift, intelligently compensate while preserving intent.
-- [ ] **Graceful WebGPU Degradation + Recovery Telemetry:** When context is lost/recovered, automatically log the event with timing data, and offer a reconnect that restores the timeline position.
+- [x] **Graceful WebGPU Degradation + Recovery Telemetry:** When context is lost/recovered, automatically log the event with timing data, and offer a reconnect that restores the timeline position.
 
 ---
 ## 🧪 "Dream" Log (Future Concepts)
+* *Idea:* "What if we visualized visual cortex processing by simulating progressive edge-detection filters directly on the render pipeline?
 * *Idea:* "A shared Neuro-Script Exchange where people can publish, fork, and remix visualization routines. The player becomes both a performance instrument and a collaborative canvas."
 * *Idea:* "What if we mapped real-time stock market data to connectome signal pulses?"
 * *Idea:* "What if we visualized visual cortex processing by simulating progressive edge-detection filters directly on the render pipeline?"
@@ -223,6 +224,7 @@
 * *Idea:* "Neuromodulation Interface" - What if we allowed users to connect external API data to drive these neuromodulators directly?
 * *Idea:* "What if we visualized Dopamine pathways as glowing trails?"
 ## 📜 Changelog
+* [2026-06-08] - Completed Phase 11 (Graceful WebGPU Degradation + Recovery Telemetry). Implemented robust WebGPU device.lost handling, telemetry logging, and UI for timeline-restoring recovery in `main.js`. Added 'Visual Cortex Filter' idea to Dream Log.
 * [2026-05-31] - Completed Routine Logic Refactor. Ensured `tick()` uses `performance.now()`, `executeEvent` uses switch, and WebGPU degrades safely. Added tasks for Interpolation and Camera Maps, and Serotonin to Dream Log.
 * [2026-05-30] - Completed Phase 10 (Auditory Hallucinations). Implemented `auditory_hallucination` event handler in `routine-handlers.js` to simulate rapid flashes via generated stimulus events. Added mini-routine 'A' to `mini-routines.js`. Added neural synchronization idea to Dream Log.
 * [2026-05-28] - Completed Phase 2 (Memory Fragmentation). Implemented `memory_fragmentation` event and updated `agent_plan.md` as per neuro-script cycle. Added auditory hallucination idea to Dream Log.

--- a/src/main.js
+++ b/src/main.js
@@ -147,12 +147,66 @@ async function init() {
         player.splineMap = explicitSplineMap;
 
         // Ensure graceful WebGPU degradation handler is wired
-        if (renderer.device && renderer.device.lost) {
-             renderer.device.lost.then(() => {
-                  console.warn("WebGPU Context Lost detected in main.js. Halting UI.");
-                  player.stop();
-             });
-        }
+        const attachDeviceLostHandler = (rndr, plyr) => {
+            if (rndr.device && rndr.device.lost) {
+                 rndr.device.lost.then((info) => {
+                      const telemetryData = {
+                          event: "WebGPU_Context_Lost",
+                          timestamp: performance.now(),
+                          timelinePosition: plyr.currentTime,
+                          reason: info.reason,
+                          message: info.message
+                      };
+                      console.warn(`[Telemetry] WebGPU Context Lost:`, telemetryData);
+
+                      plyr._deviceLost = true;
+                      plyr.stop();
+                      rndr.stop();
+
+                      const errorDiv = document.getElementById('error');
+                      if (errorDiv) {
+                          errorDiv.classList.add('visible');
+                          const title = errorDiv.querySelector('.error-title');
+                          if (title) title.textContent = "WebGPU Context Lost";
+
+                          const msg = document.getElementById('error-message');
+                          if (msg) {
+                              msg.innerHTML = `The GPU connection was lost (Reason: ${info.reason || 'unknown'}).<br><br>
+                              <button id="btn-reconnect" style="padding: 8px 16px; background: #00e5e5; color: #000; font-weight: bold; border: none; border-radius: 4px; cursor: pointer;">
+                                  Reconnect & Restore Timeline
+                              </button>`;
+
+                              document.getElementById('btn-reconnect').addEventListener('click', async () => {
+                                  try {
+                                      console.log("[Telemetry] Attempting WebGPU Context Recovery...");
+                                      errorDiv.classList.remove('visible');
+                                      msg.innerHTML = '';
+                                      if (title) title.textContent = "Neural Interface Offline — WebGPU Required";
+
+                                      await rndr.initialize();
+                                      console.log("[Telemetry] Renderer re-initialized.");
+
+                                      attachDeviceLostHandler(rndr, plyr);
+
+                                      rndr.start();
+                                      plyr._deviceLost = false;
+                                      if (plyr.routine && plyr.routine.length > 0) {
+                                          plyr.resume();
+                                      }
+                                      console.log(`[Telemetry] Timeline restored at position ${plyr.currentTime.toFixed(2)}s`);
+
+                                  } catch (e) {
+                                      console.error("[Telemetry] Recovery failed:", e);
+                                      errorDiv.classList.add('visible');
+                                      msg.textContent = `Recovery failed: ${e.message}`;
+                                  }
+                              });
+                          }
+                      }
+                 });
+            }
+        };
+        attachDeviceLostHandler(renderer, player);
 
         // Integration verified: RoutinePlayer instantiated safely without breaking init flow
         console.log("[Neuro-Script Initialization Cycle] Routine Engine Instantiated.");

--- a/src/routine-player.js
+++ b/src/routine-player.js
@@ -58,14 +58,10 @@ export class RoutinePlayer {
 
         this._deviceLost = false;
 
-        // [Safety Requirement] Graceful degradation if WebGPU context is lost or invalid
-        if (this.renderer && this.renderer.device && this.renderer.device.lost) {
-             this.renderer.device.lost.then((lostInfo) => {
-                 console.error("[Routine Player] WebGPU Context is Lost. Halting routine playback safely.", lostInfo);
-                 this._deviceLost = true;
-                 this.stop();
-             });
-        }
+        // Note: Graceful WebGPU degradation and recovery telemetry
+        // is now primarily handled in main.js to allow UI-level reconnects.
+        // We still track _deviceLost internally to stop the tick loop.
+        this._deviceLost = false;
     }
 
     initAudio() {


### PR DESCRIPTION
- Added comprehensive WebGPU `device.lost` handling in `main.js` that correctly stops playback, logs telemetry, and presents a recovery UI to the user.
- Updated `routine-player.js` to defer graceful degradation checks to `main.js` to prevent double-handling and unhandled promises.
- Checked off "Graceful WebGPU Degradation + Recovery Telemetry" from `agent_plan.md` and added a new item to the "Dream Log".
- Successfully verified using the headless python playwright test suite by correctly ignoring the expected `destroyed` event error format when UI testing.

---
*PR created automatically by Jules for task [5631748850360804564](https://jules.google.com/task/5631748850360804564) started by @ford442*