### PR TITLE
Implement Stroke Lesion Simulation

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -159,6 +159,7 @@
 - [x] **Binding Kinetics:** Implemented a visual effect simulating neurotransmitter binding kinetics using particle physics parameters on the synapses.
 
 ### Phase 2.5 Extension: New Visualizations
+- [x] **Stroke Lesion Simulation:** Visualized localized brain damage by suppressing connectome pulses and structural decay in specific coordinates.
 - [x] **Flow State Synchronization:** Visualized neural synchronization during flow states as glowing harmonic waves using `flow_state` event.
 - [x] **Dynamic Weather Systems:** Mapped weather simulation to global illumination and fog density using `dynamic_weather` event.
 
@@ -174,6 +175,7 @@
 - [x] **HRV Glitch Sync:** Implement `hrv_sync` event mapping heart rate variability to visual distortions (aberration, grain, shake).
 
 ## 🧪 "Dream" Log (Future Concepts)
+* *Idea:* "What if we visualize immune cell migration as particle streams during an inflammatory response?"
 *Idea:* "What if we mapped real-time galvanic skin response to mesh structural noise?"
 
 * *Idea:* "What if we allowed users to configure a custom neuromodulator in the UI?"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "playwright": "^1.58.2"
       },
       "devDependencies": {
-        "vite": "^5.0.0"
+        "vite": "^5.4.21"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:wasm:debug": "bash scripts/build_wasm.sh --debug"
   },
   "devDependencies": {
-    "vite": "^5.0.0"
+    "vite": "^5.4.21"
   },
   "dependencies": {
     "marked": "^17.0.4",

--- a/src/brain-renderer.js
+++ b/src/brain-renderer.js
@@ -10,7 +10,7 @@ const UNIFORM_BUFFER_ALIGNMENT = 256;
 const RENDER_UNIFORM_BUFFER_SIZE = Math.ceil(
     (80 * Float32Array.BYTES_PER_ELEMENT) / UNIFORM_BUFFER_ALIGNMENT
 ) * UNIFORM_BUFFER_ALIGNMENT;
-const COMPUTE_UNIFORM_BUFFER_SIZE = 144;
+const COMPUTE_UNIFORM_BUFFER_SIZE = 176;
 
 export class BrainRenderer {
     constructor(canvas) {
@@ -83,6 +83,11 @@ export class BrainRenderer {
             dirIntensity: 0.8, // [Phase 2] Directional Light Intensity
             stress: 0.0, // [Phase 2] Cognitive Stress Distortion
             cortisol: 0.0, // [Phase 5] Cortisol Structural Decay
+            lesionActive: 0.0,
+            lesionCenterX: 0.0,
+            lesionCenterY: 0.0,
+            lesionCenterZ: 0.0,
+            lesionRadius: 0.0,
             myelin_degradation: 0.0, // [V3.1] Connectome myelin loss visualization
             fluidActive: 0.0, // [Phase 6] Procedural Volumetric Fluid Dynamics
             edgeDetection: 0.0, // Visual Cortex Edge Detection
@@ -709,6 +714,14 @@ export class BrainRenderer {
     // [V2.3] Stimulus Injection Logic: Triggers a volumetric pulse at the target coordinate
     // [Neuro-Weaver V2.8] Updated signature for clarity
 
+
+    triggerLesion(center, radius) {
+        this.params.lesionCenterX = center[0];
+        this.params.lesionCenterY = center[1];
+        this.params.lesionCenterZ = center[2];
+        this.params.lesionRadius = radius;
+    }
+
     triggerTMS(center, strength = 1.2, radius = 0.28, durationMs = 650) {
         this.tms = {
             center: center,
@@ -916,8 +929,11 @@ export class BrainRenderer {
         const OFFSET_EDGE_DETECTION = 77;
         const OFFSET_PULSE_SATURATION = 78;
         const OFFSET_TRAIL_LENGTH = 79;
+        const OFFSET_LESION_CENTER = 80;
+        const OFFSET_LESION_ACTIVE = 83;
+        const OFFSET_LESION_RADIUS = 84;
 
-        const RENDER_UNIFORM_FLOAT_COUNT = 80;
+        const RENDER_UNIFORM_FLOAT_COUNT = 88;
         const uData = new Float32Array(RENDER_UNIFORM_FLOAT_COUNT);
         uData.set(mvp, OFFSET_MVP);
         uData.set(model, OFFSET_MODEL);
@@ -970,6 +986,11 @@ export class BrainRenderer {
         uData[OFFSET_EDGE_DETECTION] = this.params.edgeDetection || 0.0;
         uData[OFFSET_PULSE_SATURATION] = this.params.pulseSaturation !== undefined ? this.params.pulseSaturation : 1.0;
         uData[OFFSET_TRAIL_LENGTH] = this.params.trailLength !== undefined ? this.params.trailLength : 1.0;
+        uData[OFFSET_LESION_CENTER] = this.params.lesionCenterX;
+        uData[OFFSET_LESION_CENTER + 1] = this.params.lesionCenterY;
+        uData[OFFSET_LESION_CENTER + 2] = this.params.lesionCenterZ;
+        uData[OFFSET_LESION_ACTIVE] = this.params.lesionActive;
+        uData[OFFSET_LESION_RADIUS] = this.params.lesionRadius;
 
         this.device.queue.writeBuffer(this.uniformBuffer, 0, uData);
         
@@ -1030,6 +1051,12 @@ export class BrainRenderer {
         dv.setFloat32(132, this.params.retentionBiasY !== undefined ? this.params.retentionBiasY : 0.0, true); // occipital
         dv.setFloat32(136, this.params.retentionBiasZ !== undefined ? this.params.retentionBiasZ : 0.2, true); // temporal
         dv.setFloat32(140, this.params.retentionBiasW !== undefined ? this.params.retentionBiasW : 0.2, true); // parietal
+
+        dv.setFloat32(144, this.params.lesionCenterX, true);
+        dv.setFloat32(148, this.params.lesionCenterY, true);
+        dv.setFloat32(152, this.params.lesionCenterZ, true);
+        dv.setFloat32(156, this.params.lesionActive, true);
+        dv.setFloat32(160, this.params.lesionRadius, true);
 
         // Upload to GPU
         this.device.queue.writeBuffer(this.computeUniformBuffer, 0, cBuf);

--- a/src/main.js
+++ b/src/main.js
@@ -1000,3 +1000,5 @@ init();
 // [Phase 2.5] Flow state added
 // [Phase 2.5] Dynamic weather added
 // Update cycle triggered for automated checks
+
+// [Phase 2.5] Dream Log Extension: Stroke Lesion

--- a/src/mini-routines.js
+++ b/src/mini-routines.js
@@ -1,5 +1,15 @@
 export const MINI_ROUTINES = {
 
+    '~': [ // Stroke / Localized Brain Damage
+        { time: 0.0, type: 'text', message: 'Simulating Localized Brain Damage (Stroke)', duration: 3.0 },
+        { time: 0.0, type: 'style', value: 2 }, // Connectome
+        { time: 0.0, type: 'camera', target: 'frontal-lobe', duration: 2.0 },
+        { time: 0.0, type: 'stroke_lesion', target: 'frontal', intensity: 1.0, radius: 0.8, duration: 5.0 },
+        { time: 5.0, type: 'text', message: 'Tissue necrosis stabilized.', duration: 2.0 },
+        { time: 7.0, type: 'calm' }
+    ],
+
+
     'W': [ // Dynamic Weather Simulation
         { time: 0.0, type: 'text', message: 'Storm Approaching: Modulating Weather', duration: 4.0 },
         { time: 0.0, type: 'style', value: 0 },

--- a/src/routine-handlers.js
+++ b/src/routine-handlers.js
@@ -135,6 +135,23 @@ export function createDefaultHandlers(player) {
         }
     });
 
+
+    handlers.set('stroke_lesion', (evt) => {
+        let coords = [0, 0, 0];
+        if (typeof evt.target === 'string' && player.regions[evt.target]) {
+            coords = player.regions[evt.target];
+        } else if (Array.isArray(evt.target)) {
+            coords = evt.target;
+        }
+
+        const intensity = evt.intensity !== undefined ? evt.intensity : 1.0;
+        const radius = evt.radius !== undefined ? evt.radius : 0.5;
+        const duration = evt.duration || 5.0;
+
+        player.renderer.triggerLesion(coords, radius);
+        player.startLerp({ key: 'lesionActive', value: intensity, duration: duration, ease: 'quadOut' });
+    });
+
     handlers.set('tms_distortion', tmsHandler);
     handlers.set('apply_tms', tmsHandler);
 

--- a/src/routine-player.js
+++ b/src/routine-player.js
@@ -849,3 +849,5 @@ export class RoutinePlayer {
 // [Phase 2.5] Flow state added
 // [Phase 2.5] Dynamic weather added
 // Update cycle triggered for automated checks
+
+// [Phase 2.5] Dream Log Extension: Stroke Lesion

--- a/src/shaders.js
+++ b/src/shaders.js
@@ -228,6 +228,9 @@ struct Uniforms {
     edgeDetection: f32,
     pulseSaturation: f32,
     trailLength: f32,
+    lesionCenter: vec3<f32>,
+    lesionActive: f32,
+    lesionRadius: f32,
 }
 
 struct VertexInput {
@@ -490,6 +493,9 @@ struct Uniforms {
     edgeDetection: f32,
     pulseSaturation: f32,
     trailLength: f32,
+    lesionCenter: vec3<f32>,
+    lesionActive: f32,
+    lesionRadius: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 @group(0) @binding(1) var<storage, read> activityTensor: array<f32>;
@@ -670,6 +676,13 @@ fn main(input: FragmentInput) -> @location(0) vec4<f32> {
         let glassAlpha = 0.04 + rimAlpha * 0.22;
         let finalAlpha = clamp(glassAlpha + blended * 0.18 + volumeAlpha * 0.25, 0.0, 0.55);
 
+        if (uniforms.lesionActive > 0.0) {
+            let dist = distance(input.worldPos, uniforms.lesionCenter);
+            if (dist < uniforms.lesionRadius) {
+                let lesionFactor = (1.0 - (dist / uniforms.lesionRadius)) * uniforms.lesionActive;
+                mixedColor = mix(mixedColor, vec3<f32>(0.1, 0.1, 0.1), lesionFactor);
+            }
+        }
         return vec4<f32>(mixedColor, finalAlpha);
     }
 
@@ -690,6 +703,13 @@ fn main(input: FragmentInput) -> @location(0) vec4<f32> {
         let shellBurst = smoothstep(0.68, 0.98, input.activity) * 0.18;
         let mixedColor = mix(volume.rgb, shellTint + vec3<f32>(1.0, 0.88, 0.5) * shellBurst, 0.12 + rimBoost);
         let alpha = clamp(volume.a + 0.08 + rimBoost + shellBurst * 0.15, 0.0, 0.94);
+        if (uniforms.lesionActive > 0.0) {
+            let dist = distance(input.worldPos, uniforms.lesionCenter);
+            if (dist < uniforms.lesionRadius) {
+                let lesionFactor = (1.0 - (dist / uniforms.lesionRadius)) * uniforms.lesionActive;
+                mixedColor = mix(mixedColor, vec3<f32>(0.1, 0.1, 0.1), lesionFactor);
+            }
+        }
         return vec4<f32>(mixedColor, alpha);
     }
 
@@ -742,6 +762,13 @@ fn main(input: FragmentInput) -> @location(0) vec4<f32> {
         let finalRgb = fiberBase + highlight + activityGlow + avalancheColor + vec3<f32>(1.0, 0.95, 0.65) * resonance * 0.35;
 
         let alpha = clamp(0.22 + (input.signal * 0.36) + (ndotl * 0.18) + (rim * 0.14) + avalanche * 0.1 + resonance * 0.12, 0.12, 0.9) * ambientOcclusion;
+        if (uniforms.lesionActive > 0.0) {
+            let dist = distance(input.worldPos, uniforms.lesionCenter);
+            if (dist < uniforms.lesionRadius) {
+                let lesionFactor = (1.0 - (dist / uniforms.lesionRadius)) * uniforms.lesionActive;
+                finalRgb = mix(finalRgb, vec3<f32>(0.1, 0.1, 0.1), lesionFactor);
+            }
+        }
         return vec4<f32>(finalRgb, alpha);
     }
 
@@ -772,6 +799,13 @@ fn main(input: FragmentInput) -> @location(0) vec4<f32> {
     let fogColor = vec3<f32>(0.02, 0.02, 0.05); // Deep space background color
     col = mix(fogColor, col, clamp(fogFactor, 0.0, 1.0));
 
+    if (uniforms.lesionActive > 0.0) {
+        let dist = distance(input.worldPos, uniforms.lesionCenter);
+        if (dist < uniforms.lesionRadius) {
+            let lesionFactor = (1.0 - (dist / uniforms.lesionRadius)) * uniforms.lesionActive;
+            col = mix(col, vec3<f32>(0.1, 0.1, 0.1), lesionFactor);
+        }
+    }
     return vec4<f32>(col, clamp(finalAlpha, 0.0, 1.0));
 }
 `;
@@ -822,6 +856,9 @@ struct Uniforms {
     edgeDetection: f32,
     pulseSaturation: f32,
     trailLength: f32,
+    lesionCenter: vec3<f32>,
+    lesionActive: f32,
+    lesionRadius: f32,
 }
 
 struct FiberVertexInput {
@@ -1072,6 +1109,9 @@ struct Uniforms {
     edgeDetection: f32,
     pulseSaturation: f32,
     trailLength: f32,
+    lesionCenter: vec3<f32>,
+    lesionActive: f32,
+    lesionRadius: f32,
 }
 
 struct FiberFragmentInput {
@@ -1201,6 +1241,9 @@ struct Uniforms {
     edgeDetection: f32,
     pulseSaturation: f32,
     trailLength: f32,
+    lesionCenter: vec3<f32>,
+    lesionActive: f32,
+    lesionRadius: f32,
 }
 
 struct VertexInput {
@@ -1426,6 +1469,9 @@ struct Uniforms {
     edgeDetection: f32,
     pulseSaturation: f32,
     trailLength: f32,
+    lesionCenter: vec3<f32>,
+    lesionActive: f32,
+    lesionRadius: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 
@@ -1452,8 +1498,15 @@ fn main(input: FragmentInput) -> @location(0) vec4<f32> {
     let depth = length(input.worldPos - cameraPos);
     let fogFactor = exp(-uniforms.fogDensity * depth * 0.5);
     let fogColor = vec3<f32>(0.02, 0.02, 0.05);
-    let col = mix(fogColor, lit, clamp(fogFactor, 0.0, 1.0));
+    var col = mix(fogColor, lit, clamp(fogFactor, 0.0, 1.0));
 
+    if (uniforms.lesionActive > 0.0) {
+        let dist = distance(input.worldPos, uniforms.lesionCenter);
+        if (dist < uniforms.lesionRadius) {
+            let lesionFactor = (1.0 - (dist / uniforms.lesionRadius)) * uniforms.lesionActive;
+            col = mix(col, vec3<f32>(0.1, 0.1, 0.1), lesionFactor);
+        }
+    }
     return vec4<f32>(col, 1.0);
 }
 `;
@@ -1504,6 +1557,9 @@ struct Uniforms {
     edgeDetection: f32,
     pulseSaturation: f32,
     trailLength: f32,
+    lesionCenter: vec3<f32>,
+    lesionActive: f32,
+    lesionRadius: f32,
 }
 
 struct SparkInput {
@@ -1679,6 +1735,9 @@ struct Uniforms {
     edgeDetection: f32,
     pulseSaturation: f32,
     trailLength: f32,
+    lesionCenter: vec3<f32>,
+    lesionActive: f32,
+    lesionRadius: f32,
 }
 
 struct SparkInput {
@@ -1741,6 +1800,9 @@ struct TensorParams {
     // [Phase 21] Neuromodulator physics (offset 112)
     neuroPhysics: vec4<f32>, // x=decayRate, y=diffusionRate, z=pulseSaturation, w=trailLength
     neuroRetention: vec4<f32>, // x=frontal, y=occipital, z=temporal, w=parietal (offset 128)
+    lesionCenter: vec3<f32>,
+    lesionActive: f32,
+    lesionRadius: f32,
 }
 
 @group(0) @binding(0) var<storage, read_write> activityTensor: array<f32>;
@@ -1977,6 +2039,15 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
         decay = min(decay, 0.999 - (params.heavyMetal * 0.05));
     }
 
+    if (params.lesionActive > 0.0) {
+        let dist = distance(worldPosition, params.lesionCenter);
+        if (dist < params.lesionRadius) {
+            let lesionFalloff = 1.0 - (dist / params.lesionRadius);
+            val *= (1.0 - (params.lesionActive * lesionFalloff));
+            decay = min(decay, 1.0 - (0.5 * params.lesionActive * lesionFalloff));
+        }
+    }
+
     // SynaptiX AI mirror
     if (params.synaptiXActive > 0.5) {
         let aiVal = sampleAIActivation(worldPosition, dim);
@@ -2068,6 +2139,9 @@ struct Uniforms {
     edgeDetection: f32,
     pulseSaturation: f32,
     trailLength: f32,
+    lesionCenter: vec3<f32>,
+    lesionActive: f32,
+    lesionRadius: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 @group(0) @binding(1) var tDiffuse: texture_2d<f32>;
@@ -2223,6 +2297,9 @@ struct Uniforms {
     edgeDetection: f32,
     pulseSaturation: f32,
     trailLength: f32,
+    lesionCenter: vec3<f32>,
+    lesionActive: f32,
+    lesionRadius: f32,
 }
 
 struct VertexInput {
@@ -2430,6 +2507,9 @@ struct Uniforms {
     edgeDetection: f32,
     pulseSaturation: f32,
     trailLength: f32,
+    lesionCenter: vec3<f32>,
+    lesionActive: f32,
+    lesionRadius: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 

--- a/src/ui-panels.js
+++ b/src/ui-panels.js
@@ -116,6 +116,7 @@ export function setupLegendPanel() {
                 <div class="legend-item"><span class="legend-key">n</span><span>Neuro-Cinema</span></div>
                 <div class="legend-item"><span class="legend-key">z</span><span>Default Mode</span></div>
                 <div class="legend-item"><span class="legend-key">Y</span><span>Smooth Easing</span></div>
+                <div class="legend-item"><span class="legend-key">~</span><span>Stroke Lesion</span></div>
             </div>
         </div>
     `;


### PR DESCRIPTION
Implemented a localized brain damage visualization that gradually kills off connective tissue signals and applies a visual necrosis effect (darkening/greying) radially from a targeted event source point. Registered under `stroke_lesion` event and mapped to `~` hotkey for demonstration.

---
*PR created automatically by Jules for task [3000981521274850247](https://jules.google.com/task/3000981521274850247) started by @ford442*