### PR TITLE
feat: Implement Neurotransmitter Depletion Mesh Decimation

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -281,10 +281,16 @@
 * *Idea:* "What if we allowed users to 'paint' energy directly onto the tensor volume using a continuous drag gesture?"
 * *Idea:* "What if we visualized marker events as floating text particles within the tensor volume?"
 
+* *Idea:* "What if we visualized ATP energy depletion as a cascading shutdown of regional activity, culminating in a global slow-motion effect?"
+
+### Phase 2.5 Extension: Neurotransmitter Depletion
+- [x] **Gradual Mesh Decimation:** Visualized neurotransmitter depletion as gradual mesh decimation in the tensor volume using a noise function, controlled via `neurotransmitter_depletion` event.
+
 ### Phase 2.5 Extension: New Visualizations 2
 - [x] **Cognitive Dissonance Simulation:** Visualized cognitive dissonance as conflicting directional flows in the tensor volume causing localized turbulence, controlled via `cognitive_dissonance` event.
 
 ## 📜 Changelog
+* [2026-07-10] - Completed Phase 2.5 Extension (Neurotransmitter Depletion). Visualized neurotransmitter depletion as gradual mesh decimation, controlled via `neurotransmitter_depletion` event.
 * [2026-07-05] - Completed Phase 2.5 Extension (Flow State Synchronization). Visualized neural synchronization during flow states as glowing harmonic waves using `flow_state` event.
 * [2026-06-22] - Completed Phase 17 (Advanced Routine Control). Verified `clearLerps()` functionality and implemented Transcranial Magnetic Stimulation (TMS) spatial distortions via `tmsActive` uniform and `tms_distortion` events.
 * [2026-06-12] - Completed Phase 13 (Region Injection API). Implemented `injectRegion` on visualizer API and wired click-based energy injection in `main.js`. Added 'paint energy drag gesture' idea to Dream Log.

--- a/src/brain-renderer.js
+++ b/src/brain-renderer.js
@@ -89,6 +89,7 @@ export class BrainRenderer {
             lesionCenterY: 0.0,
             lesionCenterZ: 0.0,
             lesionRadius: 0.0,
+            decimation: 0.0,
             myelin_degradation: 0.0, // [V3.1] Connectome myelin loss visualization
             fluidActive: 0.0, // [Phase 6] Procedural Volumetric Fluid Dynamics
             edgeDetection: 0.0, // Visual Cortex Edge Detection
@@ -933,6 +934,7 @@ export class BrainRenderer {
         const OFFSET_LESION_CENTER = 80;
         const OFFSET_LESION_ACTIVE = 83;
         const OFFSET_LESION_RADIUS = 84;
+        const OFFSET_DECIMATION = 85;
 
         const RENDER_UNIFORM_FLOAT_COUNT = 88;
         const uData = new Float32Array(RENDER_UNIFORM_FLOAT_COUNT);
@@ -992,6 +994,7 @@ export class BrainRenderer {
         uData[OFFSET_LESION_CENTER + 2] = this.params.lesionCenterZ;
         uData[OFFSET_LESION_ACTIVE] = this.params.lesionActive;
         uData[OFFSET_LESION_RADIUS] = this.params.lesionRadius;
+        uData[OFFSET_DECIMATION] = this.params.decimation;
 
         this.device.queue.writeBuffer(this.uniformBuffer, 0, uData);
         
@@ -1059,6 +1062,7 @@ export class BrainRenderer {
         dv.setFloat32(152, this.params.lesionCenterZ, true);
         dv.setFloat32(156, this.params.lesionActive, true);
         dv.setFloat32(160, this.params.lesionRadius, true);
+        dv.setFloat32(164, this.params.decimation, true);
 
         // Upload to GPU
         this.device.queue.writeBuffer(this.computeUniformBuffer, 0, cBuf);

--- a/src/main.js
+++ b/src/main.js
@@ -1003,3 +1003,4 @@ init();
 // Update cycle triggered for automated checks
 
 // [Phase 2.5] Dream Log Extension: Stroke Lesion
+// [Phase 2.5] Dream Log Extension: Neurotransmitter Depletion

--- a/src/mini-routines.js
+++ b/src/mini-routines.js
@@ -20,6 +20,16 @@ export const MINI_ROUTINES = {
         { time: 16.0, type: 'text', message: 'Weather Normalized', duration: 3.0 }
     ],
 
+
+    'X': [ // Neurotransmitter Depletion
+        { time: 0.0, type: 'text', message: 'Simulating Neurotransmitter Depletion', duration: 4.0 },
+        { time: 0.0, type: 'style', value: 0 },
+        { time: 0.0, type: 'camera', target: 'overview', duration: 2.0, ease: 'sineInOut' },
+        { time: 1.0, type: 'neurotransmitter_depletion', intensity: 0.9, duration: 8.0, message: 'Gradual mesh decimation...' },
+        { time: 12.0, type: 'neurotransmitter_depletion', intensity: 0.0, duration: 4.0, message: 'Recovering...' },
+        { time: 16.0, type: 'text', message: 'Network Restored', duration: 3.0 },
+        { time: 17.0, type: 'calm' }
+    ],
     'F': [ // Flow State Synchronization
         { time: 0.0, type: 'text', message: 'Entering Flow State', duration: 3.0 },
         { time: 0.0, type: 'style', value: 2 }, // Connectome view

--- a/src/routine-handlers.js
+++ b/src/routine-handlers.js
@@ -1362,6 +1362,21 @@ export function createDefaultHandlers(player) {
         }
     });
 
+
+    handlers.set('neurotransmitter_depletion', (evt) => {
+        const intensity = evt.intensity !== undefined ? evt.intensity : 1.0;
+        const duration = evt.duration || 5.0;
+
+        player.startLerp({ key: 'decimation', value: intensity, duration: duration, ease: 'quadIn' });
+
+        // Dim the global brightness to match the depletion
+        player.startLerp({ key: 'ambientLight', value: Math.max(0.05, 0.2 - (0.1 * intensity)), duration: duration, ease: 'quadIn' });
+
+        if (evt.message) {
+            player.executeEvent({ type: 'text', message: evt.message, duration: duration });
+        }
+    });
+
     // Cognitive Dissonance Simulation
     handlers.set('cognitive_dissonance', (evt) => {
         const intensity = evt.intensity !== undefined ? evt.intensity : 1.0;

--- a/src/routine-player.js
+++ b/src/routine-player.js
@@ -852,3 +852,4 @@ export class RoutinePlayer {
 // Update cycle triggered for automated checks
 
 // [Phase 2.5] Dream Log Extension: Stroke Lesion
+// [Phase 2.5] Dream Log Extension: Neurotransmitter Depletion

--- a/src/shaders.js
+++ b/src/shaders.js
@@ -231,6 +231,7 @@ struct Uniforms {
     lesionCenter: vec3<f32>,
     lesionActive: f32,
     lesionRadius: f32,
+    decimation: f32,
 }
 
 struct VertexInput {
@@ -496,6 +497,7 @@ struct Uniforms {
     lesionCenter: vec3<f32>,
     lesionActive: f32,
     lesionRadius: f32,
+    decimation: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 @group(0) @binding(1) var<storage, read> activityTensor: array<f32>;
@@ -581,6 +583,12 @@ struct FragmentInput {
 fn main(input: FragmentInput) -> @location(0) vec4<f32> {
     // V2.2 Clipping: Discard pixels behind plane
     if (input.clipDist < 0.0) { discard; }
+    if (uniforms.decimation > 0.0) {
+        let noise = fract(sin(dot(input.worldPos, vec3<f32>(12.9898, 78.233, 45.164))) * 43758.5453);
+        if (noise < uniforms.decimation) { discard; }
+    }
+
+
 
     // [Phase 6] Dendritic Growth: Discard outside growth radius
     if (input.distToCenter > uniforms.growth * 1.8) { discard; }
@@ -859,6 +867,7 @@ struct Uniforms {
     lesionCenter: vec3<f32>,
     lesionActive: f32,
     lesionRadius: f32,
+    decimation: f32,
 }
 
 struct FiberVertexInput {
@@ -1112,6 +1121,7 @@ struct Uniforms {
     lesionCenter: vec3<f32>,
     lesionActive: f32,
     lesionRadius: f32,
+    decimation: f32,
 }
 
 struct FiberFragmentInput {
@@ -1134,6 +1144,12 @@ struct FiberFragmentInput {
 @fragment
 fn main(input: FiberFragmentInput) -> @location(0) vec4<f32> {
     if (input.clipDist < 0.0) { discard; }
+    if (uniforms.decimation > 0.0) {
+        let noise = fract(sin(dot(input.worldPos, vec3<f32>(12.9898, 78.233, 45.164))) * 43758.5453);
+        if (noise < uniforms.decimation) { discard; }
+    }
+
+
     if (input.distToCenter > uniforms.growth * 1.8) { discard; }
 
     let isAIFiber = input.fiberFlags.x > 0.5;
@@ -1244,6 +1260,7 @@ struct Uniforms {
     lesionCenter: vec3<f32>,
     lesionActive: f32,
     lesionRadius: f32,
+    decimation: f32,
 }
 
 struct VertexInput {
@@ -1472,6 +1489,7 @@ struct Uniforms {
     lesionCenter: vec3<f32>,
     lesionActive: f32,
     lesionRadius: f32,
+    decimation: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 
@@ -1486,6 +1504,8 @@ struct FragmentInput {
 @fragment
 fn main(input: FragmentInput) -> @location(0) vec4<f32> {
     if (input.clipDist < 0.0) { discard; }
+
+
 
     let N = normalize(input.normal);
     let V = normalize(vec3<f32>(0.0, 0.0, uniforms.zoom) - input.worldPos);
@@ -1560,6 +1580,7 @@ struct Uniforms {
     lesionCenter: vec3<f32>,
     lesionActive: f32,
     lesionRadius: f32,
+    decimation: f32,
 }
 
 struct SparkInput {
@@ -1738,6 +1759,7 @@ struct Uniforms {
     lesionCenter: vec3<f32>,
     lesionActive: f32,
     lesionRadius: f32,
+    decimation: f32,
 }
 
 struct SparkInput {
@@ -1752,6 +1774,8 @@ struct SparkInput {
 @fragment
 fn main(input: SparkInput) -> @location(0) vec4<f32> {
     if (input.clipDist < 0.0) { discard; }
+
+
 
     let falloff = exp(-dot(input.uv, input.uv) * 3.8);
     let core = pow(max(0.0, 1.0 - length(input.uv)), 2.2);
@@ -1804,6 +1828,7 @@ struct TensorParams {
     lesionCenter: vec3<f32>,
     lesionActive: f32,
     lesionRadius: f32,
+    decimation: f32,
 }
 
 @group(0) @binding(0) var<storage, read_write> activityTensor: array<f32>;
@@ -2164,6 +2189,7 @@ struct Uniforms {
     lesionCenter: vec3<f32>,
     lesionActive: f32,
     lesionRadius: f32,
+    decimation: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 @group(0) @binding(1) var tDiffuse: texture_2d<f32>;
@@ -2322,6 +2348,7 @@ struct Uniforms {
     lesionCenter: vec3<f32>,
     lesionActive: f32,
     lesionRadius: f32,
+    decimation: f32,
 }
 
 struct VertexInput {
@@ -2430,6 +2457,11 @@ fn main(input: VertexInput) -> VertexOutput {
     if (length(pos) > uniforms.growth * 1.8) {
         scale = 0.0;
     }
+    if (uniforms.decimation > 0.0) {
+        let noise = fract(sin(dot(pos, vec3<f32>(12.9898, 78.233, 45.164))) * 43758.5453);
+        if (noise < uniforms.decimation) { scale = 0.0; }
+    }
+
 
     let cameraPos = vec3<f32>(0.0, 0.0, uniforms.zoom);
     let viewDir = normalize(cameraPos - pos);
@@ -2532,6 +2564,7 @@ struct Uniforms {
     lesionCenter: vec3<f32>,
     lesionActive: f32,
     lesionRadius: f32,
+    decimation: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 
@@ -2546,6 +2579,8 @@ struct FragmentInput {
 @fragment
 fn main(input: FragmentInput) -> @location(0) vec4<f32> {
     if (input.clipDist < 0.0) { discard; }
+
+
     let d = length(input.uv);
     let typeId = input.pointData.x;
     let isAI = input.pointData.y;

--- a/src/ui-panels.js
+++ b/src/ui-panels.js
@@ -35,6 +35,8 @@ export function setupLegendPanel() {
                 <div class="legend-item"><span class="legend-key">4</span><span>Serotonin</span></div>
                 <div class="legend-item"><span class="legend-key">5</span><span>Epiphany</span></div>
                 <div class="legend-item"><span class="legend-key">F</span><span>Flow State</span></div>
+                <div class="legend-item"><span class="legend-key">X</span><span>Neurotransmitter Depletion</span></div>
+
                 <div class="legend-item"><span class="legend-key">W</span><span>Weather</span></div>
                 <div class="legend-item"><span class="legend-key">P</span><span>Panic</span></div>
                 <div class="legend-item"><span class="legend-key">6</span><span>Cortisol</span></div>


### PR DESCRIPTION
This PR implements the "Neurotransmitter Depletion as Gradual Mesh Decimation" feature sourced from the Dream Log in the project roadmap. The logic correctly adds a new `decimation` uniform (offset 85) to the WebGPU compute engine's pipeline and leverages pseudo-random noise mapping via vertex scale adjustments and fragment discard mechanisms to create a gradual procedural decay effect in the tensor volume. It is fully integrated with the RoutinePlayer sequence engine and is accessible interactively via the 'X' key.

---
*PR created automatically by Jules for task [13751787711129338613](https://jules.google.com/task/13751787711129338613) started by @ford442*