### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      # Frontend-only build. Do NOT use `npm run build` here — it shells out to
+      # scripts/build_wasm.sh, which requires an Emscripten SDK that CI does not
+      # provision. The WASM engine is an optional runtime feature (wasm-engine.js
+      # falls back gracefully when the module is absent), so it is not a build gate.
+      - name: Build frontend (vite, no WASM)
+        run: npx vite build
+
+      - name: Python smoke test
+        run: python3 scripts/test_run.py
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Playwright (Python)
+        run: pip install playwright
+
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(python3 -m playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright OS dependencies
+        run: python3 -m playwright install-deps chromium
+
+      - name: Install Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: python3 -m playwright install chromium
+
+      # Every script in verification/ forces ?renderer=webgl and launches its
+      # own dev server (see AGENTS.md #7) — WebGPU + SwiftShader is too flaky
+      # for headless CI, so the WebGL2 fallback path is the CI-supported one.
+      - name: Run verification suite (WebGL fallback)
+        run: python3 verification/verify_suite.py
+
+      - name: Upload verification screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verification-screenshots
+          path: verification/*.png
+          retention-days: 7
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,6 +331,18 @@ python verification/verify_synaptix.py   # SynaptiX AI↔Human resonance
 - `verification/test_flashback.py` — Memory flashback routine test
 - `verification/test_glitch.py` — Glitch storm routine test
 
+### 7.1 CI Contract
+
+`.github/workflows/ci.yml` runs on every push/PR to `main` and gates on:
+
+1. `npm ci`
+2. `npx vite build` — frontend-only build (never `npm run build`, which shells out to `scripts/build_wasm.sh` and requires an Emscripten SDK that CI does not provision)
+3. `python3 scripts/test_run.py` — dev server smoke test
+4. `pip install playwright && playwright install chromium`
+5. `python3 verification/verify_suite.py` — the WebGL-fallback (`?renderer=webgl`) Playwright suite described above
+
+`node_modules` and the Playwright browser cache are cached across runs. Verification screenshots are uploaded as a build artifact when the job fails. The WASM build (`npm run build:wasm`) stays a local/manual step and is **not** a CI gate unless an Emscripten toolchain is added to the workflow later.
+
 ---
 
 ## 8. Deployment Process

--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ Use the WebGL2 path when you need a visually inspectable reference renderer:
 
 The WebGL2 path shares the same geometry generator, tensor buffers, camera state, style controls, and SynaptiX inputs. It is intentionally simpler than the WebGPU renderer: it approximates compute-driven volumetrics on the CPU so the scene remains debuggable in environments where WebGPU is hard to inspect automatically.
 
+## Continuous Integration
+
+`.github/workflows/ci.yml` runs on every push and pull request to `main`:
+
+1. `npm ci`
+2. `npx vite build` — frontend-only production build. This intentionally skips `npm run build`'s `build:wasm` step, since CI does not provision an Emscripten SDK; the WASM engine is optional at runtime (see [docs/wasm-engine.md](docs/wasm-engine.md)).
+3. `python3 scripts/test_run.py` — dev server smoke test.
+4. `pip install playwright` + `playwright install chromium` — sets up the Python Playwright runtime used by the verification scripts.
+5. `python3 verification/verify_suite.py` — runs the Playwright-based visual verification suite against the `?renderer=webgl` fallback (WebGPU/SwiftShader is too unreliable for headless CI).
+
+`node_modules` and the Playwright browser cache are cached between runs. On failure, any screenshots written to `verification/` are uploaded as a build artifact for debugging. The WASM build is never a CI gate — it stays a local/manual step until an Emscripten toolchain is added to the workflow.
+
 ## Custom Neuromodulator UI
 In Phase 21, we introduced a live-editable neuromodulator interface. Located in the right-side control panel, you can now toggle between predefined chemical profiles (Dopamine, Serotonin, Acetylcholine, GABA) or create your own custom profile.
 These parameters directly map to WebGPU compute uniforms and affect:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml`, running on push/PR to `main`:
  1. `npm ci`
  2. `npx vite build` — frontend-only build. Deliberately **not** `npm run build`, since that always shells out to `scripts/build_wasm.sh`, which requires an Emscripten SDK that CI does not provision. The WASM engine already falls back gracefully at runtime when absent, so it stays outside the build gate.
  3. `python3 scripts/test_run.py` — dev-server smoke test
  4. `pip install playwright` + `playwright install-deps/install chromium`
  5. `python3 verification/verify_suite.py` — the existing Playwright verification suite, which forces the `?renderer=webgl` fallback path (WebGPU + SwiftShader is documented as too flaky for headless CI in `AGENTS.md`)
- Caches `node_modules` (via `actions/setup-node`'s built-in npm cache) and the Playwright Chromium browser (keyed on the installed Playwright version) between runs.
- Uploads any `verification/*.png` screenshots as a build artifact when the job fails, for debugging.
- Documents the CI contract in `README.md` (new "Continuous Integration" section) and `AGENTS.md` (new "7.1 CI Contract" section).

## Why not `verification/` vs `tests/verification/`?

`verification/` is the actively-maintained suite referenced throughout `AGENTS.md` and `README.md` (self-contained scripts, each spinning up its own dev server on a dedicated port and asserting on console/page errors). `tests/verification/` is a larger, partially divergent/legacy copy not wired into any documented workflow, so it was left untouched — deduplicating it is a separate concern from standing up CI.

## Test plan

- [x] `npm ci && npx vite build` succeeds locally (frontend-only, no Emscripten present)
- [x] `python3 scripts/test_run.py` passes
- [x] `pip install playwright && playwright install --with-deps chromium` succeeds
- [x] `python3 verification/verify_brain.py` launches the dev server, loads `?renderer=webgl`, and cycles styles/debug controls (confirmed the script's mechanics end-to-end in a sandboxed dev container; the one failure observed there was an `ERR_CONNECTION_RESET` on the Google Fonts stylesheet caused by this sandbox's forced outbound proxy, which headless Chromium doesn't pick up from env vars — not present on standard GitHub-hosted runners with direct internet access)
- [ ] CI run on this PR (will confirm green once Actions runs)
- [ ] Manually verified CI fails on an intentional broken import / shader syntax error (covered by `vite build` failing on bad imports, and `verify_suite.py` asserting on console/shader-compile errors surfaced in the real browser)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TgJ4gRjaDVmD64Vjz59TNS)_