### PR TITLE
Fix npm build to work without a hardcoded emsdk path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
       - name: Install Node dependencies
         run: npm ci
 
-      # Frontend-only build. Do NOT use `npm run build` here — it shells out to
-      # scripts/build_wasm.sh, which requires an Emscripten SDK that CI does not
-      # provision. The WASM engine is an optional runtime feature (wasm-engine.js
-      # falls back gracefully when the module is absent), so it is not a build gate.
+      # `npm run build` is web-only (vite build) and never requires an
+      # Emscripten SDK. The WASM engine is an optional runtime feature
+      # (wasm-engine.js falls back gracefully when the module is absent),
+      # so it is not a build gate; `npm run build:full` opts into it locally.
       - name: Build frontend (vite, no WASM)
-        run: npx vite build
+        run: npm run build
 
       - name: Python smoke test
         run: python3 scripts/test_run.py

--- a/README.md
+++ b/README.md
@@ -67,11 +67,26 @@ All three keep the existing real-time signal pulsing, soma scaling, and spark pi
 ## Common Commands
 
 ```bash
-npm run build
+npm install
+npm run dev              # dev server, http://localhost:5173
+npm run build            # web-only production build (default, no toolchain needed)
+npm run build:full       # web + optional C++ WASM hybrid engine (requires Emscripten)
 npm run preview
 python3 scripts/test_run.py
 python3 verification/verify_synaptix.py
 ```
+
+### Build tiers
+
+Neuro-Weaver's WASM engine is an optional runtime feature (`src/wasm-engine.js` falls back to the WebGPU/WebGL compute path when the module is absent), so it is never required to produce a working build:
+
+| Tier | Command | Requires Emscripten? | Produces |
+|------|---------|----------------------|----------|
+| Dev | `npm run dev` | No | Vite dev server with hot reload |
+| Web-only production | `npm run build` (alias: `npm run build:web`) | No | `dist/` — Vite bundle only |
+| Full hybrid | `npm run build:full` | Yes | `dist/` + `public/wasm/brain_tensor_engine.{js,wasm}` |
+
+`npm run build` runs a `prebuild` check (`scripts/check_wasm.sh`) that prints an advisory notice — never a failure — when `public/wasm/` hasn't been built. To build the WASM engine on its own (e.g. after installing Emscripten via `.jules/setup.sh`), run `npm run build:wasm`; it locates `em++` via `$EMSDK`, an `emsdk` checkout in the repo root or `$HOME`, or an already-activated shell, instead of a hardcoded path. See [docs/wasm-engine.md](docs/wasm-engine.md) for details.
 
 ## WebGL2 Fallback
 
@@ -88,7 +103,7 @@ The WebGL2 path shares the same geometry generator, tensor buffers, camera state
 `.github/workflows/ci.yml` runs on every push and pull request to `main`:
 
 1. `npm ci`
-2. `npx vite build` — frontend-only production build. This intentionally skips `npm run build`'s `build:wasm` step, since CI does not provision an Emscripten SDK; the WASM engine is optional at runtime (see [docs/wasm-engine.md](docs/wasm-engine.md)).
+2. `npm run build` (equivalent to `npx vite build`) — frontend-only production build. CI does not provision an Emscripten SDK, so it never runs `build:full`/`build:wasm`; the WASM engine is optional at runtime (see [docs/wasm-engine.md](docs/wasm-engine.md)).
 3. `python3 scripts/test_run.py` — dev server smoke test.
 4. `pip install playwright` + `playwright install chromium` — sets up the Python Playwright runtime used by the verification scripts.
 5. `python3 verification/verify_suite.py` — runs the Playwright-based visual verification suite against the `?renderer=webgl` fallback (WebGPU/SwiftShader is too unreliable for headless CI).

--- a/docs/wasm-engine.md
+++ b/docs/wasm-engine.md
@@ -51,19 +51,30 @@ cd emsdk
 source ./emsdk_env.sh   # (or emsdk_env.bat on Windows)
 ```
 
-The CI environment uses `.jules/setup.sh` which automates these steps.
+`.jules/setup.sh` automates these steps for agent/sandbox environments that opt into the WASM tier.
+
+`scripts/build_wasm.sh` locates `em++` in this order, so no hardcoded path is required:
+
+1. `em++` already on `PATH` (SDK activated in the current shell).
+2. `$EMSDK` env var pointing at an emsdk checkout (`$EMSDK/emsdk_env.sh`).
+3. An `emsdk/` checkout in the repo root or `$HOME` (matches `.jules/setup.sh`'s clone location).
+
+If none of these resolve, the script exits with an error explaining how to install Emscripten — it never silently no-ops.
 
 ### Compile
 
 ```bash
-# Release build (O2)
+# Release build (O2) — WASM engine only
 npm run build:wasm
 
 # Debug build (O0, assertions, safe-heap)
 npm run build:wasm:debug
+
+# Full production build: Vite bundle + WASM engine
+npm run build:full
 ```
 
-Output is placed in `public/wasm/` and served as static assets by Vite.
+Output is placed in `public/wasm/` and served as static assets by Vite. Plain `npm run build` (used by CI) is web-only and skips this entirely; see the README's "Build tiers" section for the full breakdown.
 
 ### Vite Configuration
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "npm run build:wasm && vite build",
+    "prebuild": "bash scripts/check_wasm.sh",
+    "build": "npm run build:web",
+    "build:web": "vite build",
+    "build:full": "npm run build:wasm && vite build",
     "build_colab": "npm run build:wasm_colab && vite build",
     "preview": "vite preview",
     "build:wasm": "bash scripts/build_wasm.sh",

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -14,10 +14,34 @@
 # Output: public/wasm/brain_tensor_engine.{js,wasm}
 
 set -euo pipefail
-source /root/emsdk/emsdk_env.sh
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# ─── Locate and activate the Emscripten SDK ──────────────────────────────────
+# Resolution order:
+#   1. em++ already on PATH — nothing to do.
+#   2. $EMSDK env var pointing at an emsdk checkout.
+#   3. emsdk cloned by .jules/setup.sh (git clone .../emsdk in the repo root
+#      or the user's home directory).
+if command -v em++ >/dev/null 2>&1; then
+    : # already activated in this shell
+elif [[ -n "${EMSDK:-}" && -f "${EMSDK}/emsdk_env.sh" ]]; then
+    # shellcheck disable=SC1091
+    source "${EMSDK}/emsdk_env.sh"
+elif [[ -f "${REPO_ROOT}/emsdk/emsdk_env.sh" ]]; then
+    # shellcheck disable=SC1091
+    source "${REPO_ROOT}/emsdk/emsdk_env.sh"
+elif [[ -f "${HOME}/emsdk/emsdk_env.sh" ]]; then
+    # shellcheck disable=SC1091
+    source "${HOME}/emsdk/emsdk_env.sh"
+else
+    echo "[build_wasm] ERROR: Emscripten SDK (em++) not found." >&2
+    echo "[build_wasm] Install it via .jules/setup.sh, or set \$EMSDK to an" >&2
+    echo "[build_wasm] emsdk checkout, or add em++ to PATH. See:" >&2
+    echo "[build_wasm]   https://emscripten.org/docs/getting_started/downloads.html" >&2
+    exit 1
+fi
 SRC="${REPO_ROOT}/wasm/brain_tensor_engine.cpp"
 OUT_DIR="${REPO_ROOT}/public/wasm"
 OUT_NAME="brain_tensor_engine"

--- a/scripts/check_wasm.sh
+++ b/scripts/check_wasm.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# scripts/check_wasm.sh
+# [Phase 1 WASM] Pre-build advisory check — warns (never fails) when the
+# optional WASM engine hasn't been compiled. `npm run build` only produces
+# the Vite web bundle; the WASM hybrid engine is opt-in via
+# `npm run build:full` (or `npm run build:wasm`) and requires Emscripten.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+GLUE_JS="${REPO_ROOT}/public/wasm/brain_tensor_engine.js"
+GLUE_WASM="${REPO_ROOT}/public/wasm/brain_tensor_engine.wasm"
+
+if [[ -f "${GLUE_JS}" && -f "${GLUE_WASM}" ]]; then
+    echo "[check_wasm] Found existing WASM build in public/wasm/."
+else
+    cat <<'EOF'
+[check_wasm] Notice: public/wasm/brain_tensor_engine.{js,wasm} not found.
+             This build will ship the WebGPU/WebGL renderer only — the
+             optional C++ WASM hybrid engine will not be available
+             (wasm-engine.js falls back gracefully at runtime).
+             To include it, run `npm run build:full` (requires Emscripten;
+             see .jules/setup.sh or docs/wasm-engine.md).
+EOF
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
`npm run build` previously always shelled out to `build:wasm`, which sourced a hardcoded `source /root/emsdk/emsdk_env.sh` — a path that only exists on specific CI images. Local dev and cloud agents couldn't run a production build without manual workarounds, even though the WASM engine is an optional runtime feature (`src/wasm-engine.js` already falls back gracefully when it's absent).

## Changes
- **`package.json`**: split scripts — `build` now runs `build:web` (`vite build` only, no toolchain needed); `build:full` opts into the WASM engine via the existing `build:wasm`. Added a `prebuild` hook.
- **`scripts/build_wasm.sh`**: resolves `em++` via (1) `PATH`, (2) `$EMSDK` env var, (3) an `emsdk/` checkout in the repo root or `$HOME` (matching where `.jules/setup.sh` clones it) — instead of a hardcoded `/root/emsdk` path. Exits with an actionable error message if none are found.
- **`scripts/check_wasm.sh`** (new): runs as `prebuild`; prints an advisory notice — never fails the build — when `public/wasm/` hasn't been built.
- **`README.md`**: documents the three build tiers (dev, web-only production, full hybrid) and updates the Common Commands / CI sections.
- **`docs/wasm-engine.md`**: documents the `em++` resolution order and the `build:web`/`build:full` split.
- **`.github/workflows/ci.yml`**: simplified the build step to `npm run build` now that it's web-only by default (previously called `npx vite build` directly to route around the old hardcoded-path issue).

## Verification
Ran in this sandbox (no Emscripten SDK installed, `$EMSDK` unset):
- `npm run build` — completes successfully, prints the `check_wasm.sh` advisory, and produces `dist/` via `vite build` only.
- `bash scripts/build_wasm.sh` (standalone) — fails fast with a clear message pointing to `.jules/setup.sh`/`$EMSDK`/PATH instead of an opaque "no such file" error from the old hardcoded `source`.

## Test plan
- [x] `npx vite build` / `npm run build` works without emsdk installed
- [ ] `npm run build:wasm` works when emsdk is installed via `.jules/setup.sh` (not verified in this sandbox — no Emscripten toolchain available here)
- [x] Docs updated (README, docs/wasm-engine.md); no broken default `npm run build` on fresh clones


---
_Generated by [Claude Code](https://claude.ai/code/session_01KaqsPKQjJw5d2623Yf9j5j)_