### PR TITLE
Add Neurofeedback Training Mode

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,6 +46,8 @@ python3 verification/verify_suite.py
 
 - **`audio-reactor.js`** — Web Audio API microphone input for real-time audio reactivity.
 
+- **`training-engine.js`** — Neurofeedback Training Mode: `TrainingEngine`, simulated metric samplers, built-in courses (Calm Focus / Panic Recovery / Flow Sustain), streak/drift/star scoring, and `localStorage` session history. See `docs/training-mode.md`.
+
 - **`main.js`** — Application bootstrap. Wires DOM controls, sets up keyboard shortcuts, initializes components, and runs the main update loop.
 
 ### Critical Design Principles

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,7 @@ brain_viz/
 │   ├── verify_neurochemical_fx.py # Stress/cortisol/heavy-metal, dendritic growth, sparkle
 │   ├── verify_branching.py        # Choice/branching routine logic
 │   ├── verify_glitch.py           # Glitch storm corruption simulation
+│   ├── verify_training.py         # Neurofeedback Training Mode courses + keyboard demo baseline
 │   └── *.png                      # Screenshots generated on each run (gitignored)
 ├── docs/                   # Architecture, roadmap, and mode-specific docs (see docs/ROADMAP.md, docs/archive/)
 ├── .github/
@@ -134,6 +135,7 @@ brain_viz/
 - **`wasm-engine.js`** — [Phase 1] JavaScript loader and bridge for the C++ `BrainTensorEngine` WASM module. Provides `WasmTensorEngine` class with `init()`, `update()`, `injectStimulus()`, `getTensorData()`, `benchmark()`, and `dispose()`. Gracefully falls back when WASM build is absent.
 - **`main.js`** — Wires the DOM UI to the renderer, sets up keyboard shortcuts, initializes `RoutinePlayer`, `AudioReactor`, `TensorPlayer`, and `InferenceEngine`, and runs the main update loop. Also wires the WASM engine toggle UI.
 - **`icosahedron.js`** — Static icosahedron vertex and index arrays exported as constants. Used by `brain-renderer.js` for instanced soma geometry.
+- **`training-engine.js`** — Neurofeedback Training Mode: `TrainingEngine` class, simulated 0..1 metric samplers (`calm`, `occipitalAlpha`, `flowResonance`), the `BUILTIN_COURSES` catalog (Calm Focus / Panic Recovery / Flow Sustain), streak/drift-penalty/star scoring, and `localStorage` session history. See `docs/training-mode.md`.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,6 +36,7 @@ For the current architecture and module responsibilities, see [`AGENTS.md`](../A
 | 21 | Custom Neuromodulator UI | `src/neuromodulators.js` profiles (Dopamine/Serotonin/Acetylcholine/GABA/Custom), UI panel, compute-shader integration, routine/marker hooks, `localStorage` persistence |
 | 22 | Advanced Interpolation & Extensibility | Cubic/sine easing curves, runtime-added camera regions |
 | 23 | Biofeedback Synchronization | HRV-driven glitch sync (`hrv_sync`) |
+| 24 | Neurofeedback Training Mode | `TrainingEngine`, simulated metric sampling, gamified hold-in-band objectives with streak/drift scoring and stars, `training_start`/`training_checkpoint`/`training_end` routine events with auto-branching, Training tab UI with session history, keyboard demo-baseline courses |
 
 ## Open Items
 
@@ -63,6 +64,7 @@ Deduplicated from the historical "Dream Log" entries across the archived plans �
 
 ## Related Specs & Vision Docs
 
+- [`docs/training-mode.md`](training-mode.md) — Neurofeedback Training Mode (courses, metrics, scoring, routine events)
 - [`docs/synaptix.md`](synaptix.md) / [`SYNAPTIX_SPEC.md`](SYNAPTIX_SPEC.md) — SynaptiX comparative mode
 - [`docs/webgl-fallback.md`](webgl-fallback.md) — WebGL2 fallback/debug renderer
 - [`docs/wasm-engine.md`](wasm-engine.md) — C++/WASM hybrid simulation engine

--- a/docs/training-mode.md
+++ b/docs/training-mode.md
@@ -1,0 +1,101 @@
+# Neurofeedback Training Mode
+
+A gamified mode where the player holds a simulated brain-state metric inside a
+target band for a sustained duration to complete an objective — turning
+Neuro-Weaver into an interactive neurofeedback trainer. Playable entirely
+without hardware; `AudioReactor` and SynaptiX resonance stats are used
+opportunistically when active, and a keyboard demo baseline exists for every
+built-in course so it can be exercised in headless/CI verification.
+
+## Architecture
+
+- **`src/training-engine.js`** — `TrainingEngine` class, the `METRICS` sampler
+  registry, and the `BUILTIN_COURSES` catalog. Framework-free; polled once per
+  frame via `update(dt)`.
+- **`src/routine-handlers/training.js`** — registers `training_start`,
+  `training_checkpoint`, and `training_end` routine event handlers.
+- **`src/ui/templates/tab-training.js`** / **`src/ui-training-panel.js`** —
+  the "Training" tab markup and its wiring (course picker, progress ring,
+  metric gauge, session history).
+- **`src/main-training-integration.js`** — orchestration: instantiates
+  `TrainingEngine`, attaches it to the `RoutinePlayer` as `player.trainingEngine`,
+  and wires the keyboard demo-baseline shortcuts.
+
+## Metrics
+
+Metrics are sampled 0..1 from live renderer/audio/SynaptiX state — see
+`METRICS` in `training-engine.js`:
+
+| Metric | Source | Notes |
+|---|---|---|
+| `calm` | `1 - renderer.params.stress / 2.0` | Inverse of the existing Stress (Distortion) slider. |
+| `occipitalAlpha` | `renderer.params.amplitude` / `smoothing` | Low amplitude + high smoothing (a relaxed, eyes-closed-like state) drives a simulated posterior alpha rhythm with a slow envelope wobble. |
+| `flowResonance` | SynaptiX resonance stats, else `AudioReactor` energy, else `renderer.params.flowSpeed / 10` | Falls back gracefully depending on what's active. |
+
+Extend by adding another entry to `METRICS` with a `sample(ctx)` function,
+where `ctx = { renderer, audioReactor, synaptixEngine }`.
+
+## Course JSON format
+
+```jsonc
+{
+  "id": "calm-focus",              // unique string id
+  "name": "Calm Focus",
+  "description": "...",
+  "objectives": [
+    {
+      "metric": "occipitalAlpha",  // key into METRICS
+      "target": 0.75,              // 0..1 target value
+      "tolerance": 0.15,           // +/- band around target considered "in zone"
+      "duration": 20,              // seconds of continuous in-zone hold to pass
+      "label": "Hold Alpha"        // shown in the UI / checkpoint events
+    }
+  ],
+  "demoKey": "6",                  // optional: keyboard digit that auto-starts + auto-drives this course
+  "demoParams": { "amplitude": 0.0, "smoothing": 0.98 }, // optional: renderer.params lerped on demoKey press
+  "onSuccessRoutine": "some-sub-routine-name",  // optional: sub-routine name to auto-branch into on success
+  "onFailRoutine": "some-other-sub-routine-name" // optional: sub-routine name to auto-branch into on failure
+}
+```
+
+Register a course at runtime with `trainingEngine.loadCourse(courseObject)` —
+any object matching this shape works, so custom/user-authored courses (e.g.
+loaded from a JSON file) are a drop-in extension point.
+
+## Scoring
+
+- **Hold time**: while the sampled metric is inside `[target - tolerance,
+  target + tolerance]`, `holdTime` accumulates at 1x; while outside, it decays
+  at 1.5x (a "drift penalty") and the current streak resets. An objective
+  passes once `holdTime >= duration`.
+- **Streak**: continuous in-zone seconds; `bestStreak` is tracked per course
+  run and surfaced in the UI.
+- **Stars**: on course completion, `driftPenalty` (total seconds spent out of
+  zone) is compared against the course's total objective duration — ≤5% drift
+  earns 3 stars, ≤30% earns 2, anything else that still finishes earns 1.
+- **Time limit**: a course auto-fails if the player hasn't finished within 4x
+  the sum of all objective durations, so a session can't stall forever.
+- **History**: every completed/failed run is appended to
+  `localStorage['neuro_weaver_training_history']` (see `getHistory()` /
+  `clearHistory()` in `training-engine.js`), capped at the most recent 20 runs.
+
+## Routine integration
+
+- `{ "type": "training_start", "course": "calm-focus" }` — starts a course
+  from a scripted routine JSON at a specific timeline position.
+- `{ "type": "training_checkpoint", ... }` — emitted automatically by
+  `TrainingEngine` each time an objective is passed (also authorable directly
+  in a routine as a narrative marker/text cue).
+- `{ "type": "training_end", ... }` — emitted on course completion or failure;
+  the default handler auto-branches into the course's `onSuccessRoutine` /
+  `onFailRoutine` sub-routine (registered via `player.registerSubRoutines`) if
+  one is set, giving routine authors a hook for post-course narrative beats.
+
+## Keyboard demo baseline
+
+Each built-in course ships a `demoKey` (digits `6`/`7`/`8` — `1`-`5` are
+reserved for style-mode switching and the rest of the alphabet is already
+claimed by `MINI_ROUTINES`). Pressing it starts that course and lerps the
+renderer params in `demoParams` straight into the target band, so every
+course is completable hands-free — this is what
+`verification/verify_training.py` exercises under the WebGL2 fallback.

--- a/src/main-training-integration.js
+++ b/src/main-training-integration.js
@@ -1,0 +1,30 @@
+// Extracted from main.js — Neurofeedback Training Mode wiring.
+import { TrainingEngine, BUILTIN_COURSES } from './training-engine.js';
+import { setupTrainingPanel } from './ui-training-panel.js';
+
+export function setupTrainingIntegration(renderer, player, audioReactor, synaptixEngine) {
+    const trainingEngine = new TrainingEngine(renderer, audioReactor, synaptixEngine, player);
+    player.trainingEngine = trainingEngine;
+
+    setupTrainingPanel(trainingEngine);
+
+    // Keyboard demo baseline: each built-in course plays without any hardware or
+    // mouse interaction — press its digit key to start the course and drive its
+    // metric straight into the target band via the existing lerp/param pipeline.
+    document.addEventListener('keydown', (e) => {
+        const tag = (e.target && e.target.tagName) || '';
+        const typing = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || (e.target && e.target.isContentEditable);
+        if (typing || e.ctrlKey || e.metaKey || e.altKey) return;
+
+        const course = BUILTIN_COURSES.find((c) => c.demoKey === e.key);
+        if (!course) return;
+
+        trainingEngine.startCourse(course.id);
+        for (const [key, value] of Object.entries(course.demoParams || {})) {
+            player.startLerp({ key, value, duration: 1.5, ease: 'sineInOut' });
+        }
+        console.log(`[Training] Keyboard demo baseline triggered for '${course.name}' (key '${e.key}')`);
+    });
+
+    return trainingEngine;
+}

--- a/src/main-update-loop.js
+++ b/src/main-update-loop.js
@@ -1,10 +1,17 @@
 // main-update-loop.js — RAF loop syncing UI, SynaptiX, audio reactivity, and routine transport
-export function startMainUpdateLoop(renderer, player, inputs, labels, tensorPlayer, synaptixEngine, inferenceEngine, audioReactor, transport, directorLabels, modeSelector, aiPromptRef) {
+export function startMainUpdateLoop(renderer, player, inputs, labels, tensorPlayer, synaptixEngine, inferenceEngine, audioReactor, transport, directorLabels, modeSelector, aiPromptRef, trainingEngine) {
     let lastAIStep = 0;
+    let lastTrainingTime = 0;
     const liveSourceStatus = document.getElementById('live-source-status');
 
     const updateLoop = (timestamp) => {
         tensorPlayer.update(timestamp);
+
+        if (trainingEngine) {
+            const dt = lastTrainingTime > 0 ? Math.min(0.1, (timestamp - lastTrainingTime) / 1000) : 0;
+            lastTrainingTime = timestamp;
+            trainingEngine.update(dt);
+        }
 
         if (synaptixEngine) synaptixEngine.update(timestamp);
 

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import { collectInputsAndLabels } from './main-dom.js';
 import { setupRendererBackend } from './main-renderer-setup.js';
 import { setupRoutineEngine } from './main-routine-engine.js';
 import { setupSynaptiXIntegration } from './main-synaptix-integration.js';
+import { setupTrainingIntegration } from './main-training-integration.js';
 import { startMainUpdateLoop } from './main-update-loop.js';
 
 async function init() {
@@ -28,7 +29,7 @@ async function init() {
         const legendPanel = document.getElementById('legend-panel');
         if (legendPanel) {
             const newEntry = document.createElement('div');
-            newEntry.innerHTML = '<b>1-5</b> : Switch Mode (Organic/Cyber/Connectome/Heatmap/SynaptiX)<br><b>M</b> : Memory Fragmentation<br><b>S</b> : Frontal Tour (Spline)<br><b>D</b> : Dynamic Topology Shift<br><b>X</b> : SynaptiX Mode';
+            newEntry.innerHTML = '<b>1-5</b> : Switch Mode (Organic/Cyber/Connectome/Heatmap/SynaptiX)<br><b>M</b> : Memory Fragmentation<br><b>S</b> : Frontal Tour (Spline)<br><b>D</b> : Dynamic Topology Shift<br><b>X</b> : SynaptiX Mode<br><b>6/7/8</b> : Training Demo (Calm Focus/Panic Recovery/Flow Sustain)';
             legendPanel.appendChild(newEntry);
         }
 
@@ -45,6 +46,7 @@ async function init() {
 
         setupBciPanel(renderer, controls, tensorPlayer);
         setupNeuromodulatorPanel(renderer, controls);
+        const trainingEngine = setupTrainingIntegration(renderer, player, audioReactor, synaptixEngine);
 
         initUIControls(renderer, inputs, labels);
 
@@ -68,7 +70,7 @@ async function init() {
         const directorLabels = initDirectorTools(renderer, player);
 
         startMainUpdateLoop(renderer, player, inputs, labels, tensorPlayer, synaptixEngine,
-            inferenceEngine, audioReactor, transport, directorLabels, modeSelector, aiPromptRef);
+            inferenceEngine, audioReactor, transport, directorLabels, modeSelector, aiPromptRef, trainingEngine);
 
         await inferenceEngine.initialize();
         const liveSourceStatus = document.getElementById('live-source-status');

--- a/src/routine-handlers.js
+++ b/src/routine-handlers.js
@@ -4,6 +4,7 @@ import { registerEffectsAudioHandlers } from './routine-handlers/effects-audio.j
 import { registerNarrativeFlowHandlers } from './routine-handlers/narrative-flow.js';
 import { registerSynaptixHandlers } from './routine-handlers/synaptix.js';
 import { registerBiosyncHandlers } from './routine-handlers/biosync.js';
+import { registerTrainingHandlers } from './routine-handlers/training.js';
 
 export function createDefaultHandlers(player) {
     const handlers = new Map();
@@ -13,5 +14,6 @@ export function createDefaultHandlers(player) {
     registerNarrativeFlowHandlers(handlers, player);
     registerSynaptixHandlers(handlers, player);
     registerBiosyncHandlers(handlers, player);
+    registerTrainingHandlers(handlers, player);
     return handlers;
 }

--- a/src/routine-handlers/training.js
+++ b/src/routine-handlers/training.js
@@ -1,0 +1,30 @@
+// [Neuro-Weaver] Neurofeedback Training Mode routine events.
+// `training_start` lets a routine JSON kick off a course at a scripted time.
+// `training_checkpoint` is emitted by TrainingEngine as objectives are passed
+// (also authorable directly in a routine as a narrative marker).
+// `training_end` is emitted on course completion/failure and drives routine
+// auto-branching via the course's `onSuccessRoutine` / `onFailRoutine` sub-routine names.
+export function registerTrainingHandlers(handlers, player) {
+    handlers.set('training_start', (evt) => {
+        if (!player.trainingEngine) {
+            console.warn('[Training] No TrainingEngine attached to player; cannot start course.');
+            return;
+        }
+        player.trainingEngine.startCourse(evt.course);
+    });
+
+    handlers.set('training_checkpoint', (evt) => {
+        console.log(`[Training] Checkpoint reached: ${evt.label || evt.index}`);
+        if (evt.message) {
+            player.executeEvent({ type: 'text', message: evt.message, duration: evt.duration || 2.0 });
+        }
+    });
+
+    handlers.set('training_end', (evt) => {
+        const branchName = evt.success ? evt.autoBranchSuccess : evt.autoBranchFail;
+        if (branchName && player.subRoutines[branchName]) {
+            console.log(`[Training] Auto-branching into sub-routine: ${branchName}`);
+            player.playNow(player.subRoutines[branchName]);
+        }
+    });
+}

--- a/src/training-engine.js
+++ b/src/training-engine.js
@@ -1,0 +1,321 @@
+// src/training-engine.js
+// [Neuro-Weaver] Neurofeedback Training Mode — gamified objectives that ask the
+// player to hold a simulated brain-state metric inside a target band for a
+// sustained duration. Playable with nothing but the existing sliders/keyboard;
+// AudioReactor and SynaptiX resonance stats are used opportunistically when active.
+//
+// Course JSON schema (see docs/training-mode.md for the full write-up):
+//   {
+//     id, name, description,
+//     objectives: [ { metric, target, tolerance, duration, label } ],
+//     demoKey, demoParams: { [rendererParamKey]: value }
+//   }
+
+const HISTORY_KEY = 'neuro_weaver_training_history';
+const HISTORY_LIMIT = 20;
+
+/**
+ * Metric samplers. Each returns a 0..1 value from live renderer/audio/SynaptiX
+ * state. Metrics are intentionally simulated (no real EEG hardware required)
+ * but are driven by real, user-controllable renderer parameters so a course
+ * is genuinely playable via the existing sliders.
+ */
+export const METRICS = {
+    calm: {
+        label: 'Calm (inverse cognitive stress)',
+        sample: (ctx) => {
+            const stress = ctx.renderer?.params?.stress ?? 0;
+            return clamp01(1.0 - stress / 2.0);
+        }
+    },
+    occipitalAlpha: {
+        label: 'Occipital Alpha Power',
+        sample: (ctx) => {
+            const p = ctx.renderer?.params || {};
+            // Relaxed, eyes-closed-like states (low amplitude, high smoothing)
+            // produce a stronger simulated posterior alpha rhythm.
+            const relaxation = clamp01(1.0 - (p.amplitude ?? 0.5) / 1.2) * (p.smoothing ?? 0.9);
+            const t = performance.now() / 1000;
+            const envelope = 0.5 + 0.5 * Math.sin(t * 2 * Math.PI * 0.12); // slow ~0.12Hz envelope wobble
+            // Narrow wobble band (0.8-0.9x) so a fully relaxed state (relaxation ~= 0.98)
+            // stays inside a target/tolerance band of 0.75+/-0.15 the whole cycle, while an
+            // unrelaxed default state (relaxation ~= 0.5) stays clearly outside it.
+            return clamp01(relaxation * (0.8 + 0.1 * envelope));
+        }
+    },
+    flowResonance: {
+        label: 'Flow / Resonance',
+        sample: (ctx) => {
+            const stats = ctx.synaptixEngine?.computeResonanceStats?.(ctx.renderer?._lastHumanTensor);
+            if (stats && (stats.resonance || stats.humanEnergy || stats.aiEnergy)) {
+                return clamp01(stats.resonance / 100);
+            }
+            if (ctx.audioReactor?.isActive) {
+                return clamp01(ctx.audioReactor.getFeatures().energy);
+            }
+            const flowSpeed = ctx.renderer?.params?.flowSpeed ?? 4.0;
+            return clamp01(flowSpeed / 10.0);
+        }
+    }
+};
+
+function clamp01(v) {
+    return Math.max(0, Math.min(1, v));
+}
+
+/** Built-in preset courses. Extend by pushing additional course objects here
+ * or by loading external JSON matching the same shape via loadCourse(). */
+export const BUILTIN_COURSES = [
+    {
+        id: 'calm-focus',
+        name: 'Calm Focus',
+        description: 'Relax into a steady, alert state — hold occipital alpha power in the target band for 20s.',
+        objectives: [
+            { metric: 'occipitalAlpha', target: 0.75, tolerance: 0.15, duration: 20, label: 'Hold Alpha' }
+        ],
+        demoKey: '6',
+        demoParams: { amplitude: 0.0, smoothing: 0.98 }
+    },
+    {
+        id: 'panic-recovery',
+        name: 'Panic Recovery',
+        description: 'Bring a cognitive-stress spike back down and hold calm for 15s.',
+        objectives: [
+            { metric: 'calm', target: 0.85, tolerance: 0.15, duration: 15, label: 'Recover Calm' }
+        ],
+        demoKey: '7',
+        demoParams: { stress: 0.0 }
+    },
+    {
+        id: 'flow-sustain',
+        name: 'Flow Sustain',
+        description: 'Sustain rising resonance across three checkpoints without dropping out of the zone.',
+        objectives: [
+            { metric: 'flowResonance', target: 0.6, tolerance: 0.2, duration: 10, label: 'Checkpoint 1' },
+            { metric: 'flowResonance', target: 0.7, tolerance: 0.15, duration: 10, label: 'Checkpoint 2' },
+            { metric: 'flowResonance', target: 0.8, tolerance: 0.15, duration: 10, label: 'Checkpoint 3' }
+        ],
+        demoKey: '8',
+        demoParams: { flowSpeed: 7.5 }
+    }
+];
+
+function readHistory() {
+    try {
+        const raw = localStorage.getItem(HISTORY_KEY);
+        return raw ? JSON.parse(raw) : [];
+    } catch (e) {
+        console.warn('[Training] Could not read session history from localStorage', e);
+        return [];
+    }
+}
+
+function writeHistory(entries) {
+    try {
+        localStorage.setItem(HISTORY_KEY, JSON.stringify(entries.slice(0, HISTORY_LIMIT)));
+    } catch (e) {
+        console.warn('[Training] Could not save session history to localStorage', e);
+    }
+}
+
+export class TrainingEngine {
+    constructor(renderer, audioReactor, synaptixEngine, player) {
+        this.renderer = renderer;
+        this.audioReactor = audioReactor;
+        this.synaptixEngine = synaptixEngine;
+        this.player = player;
+
+        this.courses = [...BUILTIN_COURSES];
+        this.activeCourse = null;
+        this.objectiveIndex = 0;
+        this.holdTime = 0;
+        this.streak = 0;
+        this.bestStreak = 0;
+        this.driftPenalty = 0;
+        this.elapsed = 0;
+        this.isRunning = false;
+        this.onEvent = null; // callback(evt) for UI wiring
+    }
+
+    getCourse(id) {
+        return this.courses.find((c) => c.id === id) || null;
+    }
+
+    /** Register an externally-loaded course (must match the BUILTIN_COURSES shape). */
+    loadCourse(course) {
+        if (!course || !course.id || !Array.isArray(course.objectives) || course.objectives.length === 0) {
+            console.warn('[Training] Rejected invalid course definition', course);
+            return false;
+        }
+        this.courses = this.courses.filter((c) => c.id !== course.id);
+        this.courses.push(course);
+        return true;
+    }
+
+    startCourse(courseId) {
+        const course = this.getCourse(courseId);
+        if (!course) {
+            console.warn(`[Training] Unknown course: ${courseId}`);
+            return false;
+        }
+        this.activeCourse = course;
+        this.objectiveIndex = 0;
+        this.holdTime = 0;
+        this.streak = 0;
+        this.bestStreak = 0;
+        this.driftPenalty = 0;
+        this.elapsed = 0;
+        this.isRunning = true;
+
+        console.log(`[Training] Course started: ${course.name}`);
+        this._emit({ type: 'start', course });
+        return true;
+    }
+
+    stopCourse(reason = 'aborted') {
+        if (!this.isRunning) return;
+        this.isRunning = false;
+        this._emit({ type: 'end', course: this.activeCourse, success: false, reason, stars: 0 });
+        this.activeCourse = null;
+    }
+
+    get currentObjective() {
+        return this.activeCourse ? this.activeCourse.objectives[this.objectiveIndex] : null;
+    }
+
+    /** Called once per animation frame from the main update loop. */
+    update(dt) {
+        if (!this.isRunning || !this.activeCourse) return;
+        const objective = this.currentObjective;
+        if (!objective) return;
+
+        const metric = METRICS[objective.metric];
+        if (!metric) {
+            console.warn(`[Training] Unknown metric: ${objective.metric}`);
+            this.stopCourse('bad_metric');
+            return;
+        }
+
+        const ctx = { renderer: this.renderer, audioReactor: this.audioReactor, synaptixEngine: this.synaptixEngine };
+        const value = metric.sample(ctx);
+        const low = objective.target - objective.tolerance;
+        const high = objective.target + objective.tolerance;
+        const inZone = value >= low && value <= high;
+
+        this.elapsed += dt;
+
+        if (inZone) {
+            this.holdTime += dt;
+            this.streak += dt;
+            this.bestStreak = Math.max(this.bestStreak, this.streak);
+        } else {
+            this.holdTime = Math.max(0, this.holdTime - dt * 1.5);
+            this.driftPenalty += dt;
+            this.streak = 0;
+        }
+
+        this._emit({
+            type: 'progress',
+            course: this.activeCourse,
+            objectiveIndex: this.objectiveIndex,
+            objective,
+            value,
+            band: [low, high],
+            inZone,
+            holdTime: this.holdTime,
+            streak: this.streak,
+            bestStreak: this.bestStreak
+        });
+
+        if (this.holdTime >= objective.duration) {
+            this._advanceObjective();
+            return;
+        }
+
+        // Generous overall time budget: 4x the total objective duration across the course.
+        const totalDuration = this.activeCourse.objectives.reduce((sum, o) => sum + o.duration, 0);
+        if (this.elapsed > totalDuration * 4) {
+            this._completeCourse(false);
+        }
+    }
+
+    _advanceObjective() {
+        const course = this.activeCourse;
+        const passedIndex = this.objectiveIndex;
+        this._emit({ type: 'checkpoint', course, objectiveIndex: passedIndex, passed: true });
+        if (this.player) {
+            this.player.executeEvent({
+                type: 'training_checkpoint',
+                course: course.id,
+                index: passedIndex,
+                label: course.objectives[passedIndex].label
+            });
+        }
+
+        if (this.objectiveIndex + 1 >= course.objectives.length) {
+            this._completeCourse(true);
+        } else {
+            this.objectiveIndex += 1;
+            this.holdTime = 0;
+            this.streak = 0;
+        }
+    }
+
+    _completeCourse(success) {
+        const course = this.activeCourse;
+        const stars = success ? this._computeStars() : 0;
+
+        this.isRunning = false;
+        addHistoryEntry({
+            courseId: course.id,
+            name: course.name,
+            date: new Date().toISOString(),
+            success,
+            stars,
+            driftPenalty: Math.round(this.driftPenalty * 10) / 10,
+            elapsed: Math.round(this.elapsed * 10) / 10
+        });
+
+        this._emit({ type: 'end', course, success, stars, driftPenalty: this.driftPenalty });
+        if (this.player) {
+            this.player.executeEvent({
+                type: 'training_end',
+                course: course.id,
+                success,
+                stars,
+                autoBranchSuccess: course.onSuccessRoutine,
+                autoBranchFail: course.onFailRoutine
+            });
+        }
+        this.activeCourse = null;
+    }
+
+    _computeStars() {
+        const totalDuration = this.activeCourse.objectives.reduce((sum, o) => sum + o.duration, 0);
+        const driftRatio = this.driftPenalty / Math.max(1, totalDuration);
+        if (driftRatio <= 0.05) return 3;
+        if (driftRatio <= 0.3) return 2;
+        return 1;
+    }
+
+    _emit(evt) {
+        if (typeof this.onEvent === 'function') {
+            this.onEvent(evt);
+        }
+    }
+}
+
+export function addHistoryEntry(entry) {
+    const history = readHistory();
+    history.unshift(entry);
+    writeHistory(history);
+    return history;
+}
+
+export function getHistory() {
+    return readHistory();
+}
+
+export function clearHistory() {
+    writeHistory([]);
+}

--- a/src/ui-panels.js
+++ b/src/ui-panels.js
@@ -6,3 +6,4 @@ export { setupOverlays } from './ui-overlays.js';
 export { setupRoutineTransport } from './ui-routine-transport.js';
 export { setupBciPanel } from './ui-bci-panel.js';
 export { setupNeuromodulatorPanel } from './ui-neuromodulator-panel.js';
+export { setupTrainingPanel } from './ui-training-panel.js';

--- a/src/ui-training-panel.js
+++ b/src/ui-training-panel.js
@@ -1,0 +1,118 @@
+// ui-training-panel.js — wires the Training tab (course picker, progress ring,
+// live metric gauge, session history) to a TrainingEngine instance.
+import { getHistory, clearHistory } from './training-engine.js';
+
+function formatSeconds(s) {
+    return `${s.toFixed(1)}s`;
+}
+
+function renderHistoryList(listEl) {
+    const history = getHistory();
+    if (history.length === 0) {
+        listEl.innerHTML = '<div style="color:#556677;">No sessions yet.</div>';
+        return;
+    }
+    listEl.innerHTML = history.map((entry) => {
+        const stars = '★'.repeat(entry.stars) + '☆'.repeat(3 - entry.stars);
+        const status = entry.success ? stars : 'incomplete';
+        const date = new Date(entry.date);
+        const dateStr = isNaN(date.getTime()) ? '' : date.toLocaleTimeString();
+        return `<div>${dateStr} — <b>${entry.name}</b>: ${status}</div>`;
+    }).join('');
+}
+
+export function setupTrainingPanel(trainingEngine) {
+    const courseSelect = document.getElementById('training-course-select');
+    const courseDesc = document.getElementById('training-course-desc');
+    const btnStart = document.getElementById('btn-training-start');
+    const btnStop = document.getElementById('btn-training-stop');
+    const ring = document.getElementById('training-ring');
+    const ringLabel = document.getElementById('training-ring-label');
+    const objectiveLabel = document.getElementById('training-objective-label');
+    const metricBar = document.getElementById('training-metric-bar');
+    const metricVal = document.getElementById('training-metric-val');
+    const streakVal = document.getElementById('val-training-streak');
+    const bestVal = document.getElementById('val-training-best');
+    const historyList = document.getElementById('training-history-list');
+    const btnClearHistory = document.getElementById('btn-training-clear-history');
+
+    if (!courseSelect) return; // Training tab not present in this DOM
+
+    const syncDescription = () => {
+        const course = trainingEngine.getCourse(courseSelect.value);
+        if (courseDesc) courseDesc.textContent = course ? course.description : '';
+    };
+
+    const resetRing = () => {
+        if (ring) ring.style.background = 'conic-gradient(#334455 0deg, #334455 360deg)';
+        if (ringLabel) ringLabel.textContent = '--';
+        if (objectiveLabel) objectiveLabel.textContent = 'No active course';
+        if (metricBar) metricBar.style.width = '0%';
+        if (metricVal) metricVal.textContent = 'value: -- · band: --';
+        if (streakVal) streakVal.textContent = '0.0s';
+        if (bestVal) bestVal.textContent = '0.0s';
+    };
+
+    courseSelect.addEventListener('change', syncDescription);
+    syncDescription();
+    renderHistoryList(historyList);
+
+    if (btnStart) {
+        btnStart.addEventListener('click', () => {
+            trainingEngine.startCourse(courseSelect.value);
+        });
+    }
+    if (btnStop) {
+        btnStop.addEventListener('click', () => {
+            trainingEngine.stopCourse('manual');
+        });
+    }
+    if (btnClearHistory) {
+        btnClearHistory.addEventListener('click', () => {
+            clearHistory();
+            renderHistoryList(historyList);
+        });
+    }
+
+    trainingEngine.onEvent = (evt) => {
+        if (evt.type === 'start') {
+            if (courseSelect && courseSelect.value !== evt.course.id) {
+                courseSelect.value = evt.course.id;
+                syncDescription();
+            }
+            if (objectiveLabel) objectiveLabel.textContent = `${evt.course.name}: ${evt.course.objectives[0].label}`;
+            return;
+        }
+
+        if (evt.type === 'progress') {
+            const pct = Math.min(1, evt.holdTime / evt.objective.duration);
+            const color = evt.inZone ? '#00e5e5' : '#ffaa00';
+            if (ring) ring.style.background = `conic-gradient(${color} ${Math.round(pct * 360)}deg, #223344 ${Math.round(pct * 360)}deg)`;
+            if (ringLabel) ringLabel.textContent = `${Math.round(pct * 100)}%`;
+            if (objectiveLabel) {
+                objectiveLabel.textContent = `${evt.course.name}: ${evt.objective.label} (${evt.objectiveIndex + 1}/${evt.course.objectives.length})`;
+            }
+            if (metricBar) {
+                metricBar.style.width = `${Math.round(evt.value * 100)}%`;
+                metricBar.style.background = color;
+            }
+            if (metricVal) {
+                metricVal.textContent = `value: ${evt.value.toFixed(2)} · band: ${evt.band[0].toFixed(2)}–${evt.band[1].toFixed(2)}`;
+            }
+            if (streakVal) streakVal.textContent = formatSeconds(evt.streak);
+            if (bestVal) bestVal.textContent = formatSeconds(evt.bestStreak);
+            return;
+        }
+
+        if (evt.type === 'end') {
+            if (objectiveLabel) {
+                objectiveLabel.textContent = evt.success
+                    ? `${evt.course.name} complete! ${'★'.repeat(evt.stars)}${'☆'.repeat(3 - evt.stars)}`
+                    : `${evt.course.name}: session ended (${evt.reason || 'time limit'})`;
+            }
+            renderHistoryList(historyList);
+        }
+    };
+
+    resetRing();
+}

--- a/src/ui/styles/controls.css
+++ b/src/ui/styles/controls.css
@@ -291,7 +291,7 @@ button:disabled {
 hr { border: 0; border-top: 1px solid rgba(100, 150, 200, 0.1); margin: 12px 0; }
 
 /* Tab bar styling */
-.tab-bar { display: flex; gap: 4px; margin-bottom: 12px; border-bottom: 1px solid #444; padding-bottom: 4px; }
+.tab-bar { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 12px; border-bottom: 1px solid #444; padding-bottom: 4px; }
 .tab-btn {
     flex: 1;
     background: #222;

--- a/src/ui/templates/shell.js
+++ b/src/ui/templates/shell.js
@@ -8,6 +8,7 @@ import { renderStimulusTab } from './tab-stimulus.js';
 import { renderCinematicTab } from './tab-cinematic.js';
 import { renderLightingTab } from './tab-lighting.js';
 import { renderSynaptixTab } from './tab-synaptix.js';
+import { renderTrainingTab } from './tab-training.js';
 
 const TABS = [
     { id: 'tab-activity', label: 'Activity', render: renderActivityTab },
@@ -16,6 +17,7 @@ const TABS = [
     { id: 'tab-cinematic', label: 'Cinematic', render: renderCinematicTab },
     { id: 'tab-lighting', label: 'Lighting', render: renderLightingTab },
     { id: 'tab-synaptix', label: 'SynaptiX', render: renderSynaptixTab },
+    { id: 'tab-training', label: 'Training', render: renderTrainingTab },
 ];
 
 function renderTabBar() {

--- a/src/ui/templates/tab-training.js
+++ b/src/ui/templates/tab-training.js
@@ -1,0 +1,52 @@
+// [Neuro-Weaver] Neurofeedback Training tab: course picker, live objective ring/gauge, session history.
+// Course options here mirror `BUILTIN_COURSES` in src/training-engine.js — keep both in sync.
+export function renderTrainingTab() {
+    return `<div id="tab-training" class="tab-pane">
+                <div class="section-header expanded" data-section="training-course">Neurofeedback Course</div>
+                <div class="section-content">
+                    <div class="control-group">
+                        <label data-tooltip="Hold a simulated brain-state metric inside its target band to complete the course">Course</label>
+                        <select id="training-course-select">
+                            <option value="calm-focus">Calm Focus</option>
+                            <option value="panic-recovery">Panic Recovery</option>
+                            <option value="flow-sustain">Flow Sustain</option>
+                        </select>
+                        <div id="training-course-desc" style="margin-top:4px;font-size:10px;color:#8899aa;line-height:1.35;"></div>
+                    </div>
+                    <div class="control-group" style="display:flex;gap:6px;">
+                        <button id="btn-training-start" type="button"
+                            style="flex:1;padding:8px;background:#0a2a1a;border:1px solid rgba(0,229,100,0.3);border-radius:6px;color:#88ffaa;font-size:12px;cursor:pointer;">▶ Start Course</button>
+                        <button id="btn-training-stop" type="button"
+                            style="flex:1;padding:8px;background:#2a0a0a;border:1px solid rgba(255,80,80,0.3);border-radius:6px;color:#ff9999;font-size:12px;cursor:pointer;">■ Stop</button>
+                    </div>
+
+                    <div class="control-group" style="display:flex;align-items:center;gap:12px;margin-top:8px;">
+                        <div id="training-ring" style="width:64px;height:64px;border-radius:50%;background:conic-gradient(#334455 0deg,#334455 360deg);display:flex;align-items:center;justify-content:center;flex-shrink:0;">
+                            <div id="training-ring-label" style="width:48px;height:48px;border-radius:50%;background:#0a1420;display:flex;align-items:center;justify-content:center;font-size:11px;color:#00e5e5;">--</div>
+                        </div>
+                        <div style="flex:1;">
+                            <div id="training-objective-label" style="font-size:11px;color:#ddeeff;margin-bottom:4px;">No active course</div>
+                            <div style="height:6px;background:#0a1a2a;border-radius:3px;overflow:hidden;">
+                                <div id="training-metric-bar" style="width:0%;height:100%;background:#00e5e5;transition:width 0.2s;"></div>
+                            </div>
+                            <div id="training-metric-val" style="font-size:10px;color:#8899aa;margin-top:3px;">value: -- · band: --</div>
+                        </div>
+                    </div>
+
+                    <div class="control-group" style="display:flex;gap:14px;margin-top:6px;font-size:10px;color:#8899aa;">
+                        <span>Streak <span id="val-training-streak" style="color:#00ffaa;font-family:var(--font-mono);">0.0s</span></span>
+                        <span>Best <span id="val-training-best" style="color:#00ffaa;font-family:var(--font-mono);">0.0s</span></span>
+                    </div>
+                    <div style="font-size:9px;color:#556677;margin-top:2px;">
+                        Keyboard demo baseline: press <b>6</b> (Calm Focus) / <b>7</b> (Panic Recovery) / <b>8</b> (Flow Sustain) to start &amp; auto-drive that course's metric hands-free.
+                    </div>
+                </div>
+
+                <div class="section-header" data-section="training-history">Session History</div>
+                <div class="section-content">
+                    <div id="training-history-list" style="font-size:10px;color:#aabbcc;line-height:1.6;max-height:140px;overflow-y:auto;"></div>
+                    <button id="btn-training-clear-history" type="button"
+                        style="width:100%;margin-top:6px;padding:5px;background:#1a1a1a;border:1px solid #444;border-radius:5px;color:#999;font-size:10px;cursor:pointer;">Clear History</button>
+                </div>
+            </div>`;
+}

--- a/verification/verify_suite.py
+++ b/verification/verify_suite.py
@@ -19,6 +19,7 @@ SCRIPTS = [
     "verify_neurochemical_fx.py",
     "verify_branching.py",
     "verify_glitch.py",
+    "verify_training.py",
 ]
 
 

--- a/verification/verify_training.py
+++ b/verification/verify_training.py
@@ -1,0 +1,140 @@
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from urllib.request import urlopen
+
+from playwright.sync_api import sync_playwright
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_URL = "http://127.0.0.1:5186/?renderer=webgl"
+
+
+def wait_for_server(url: str, timeout: float = 25.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with urlopen(url, timeout=1.5) as response:
+                if response.status == 200:
+                    return
+        except Exception:
+            time.sleep(0.5)
+    raise RuntimeError(f"Timed out waiting for dev server: {url}")
+
+
+def launch_dev_server() -> subprocess.Popen:
+    return subprocess.Popen(
+        ["npm", "run", "dev", "--", "--host", "127.0.0.1", "--port", "5186", "--strictPort"],
+        cwd=ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def verify() -> None:
+    server = launch_dev_server()
+    try:
+        wait_for_server(APP_URL.replace("?renderer=webgl", ""))
+        output_dir = ROOT / "verification"
+        output_dir.mkdir(exist_ok=True)
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch(
+                headless=True,
+                args=["--no-sandbox", "--disable-gpu"],
+            )
+            page = browser.new_page(viewport={"width": 1440, "height": 960})
+            errors = []
+            page.on("pageerror", lambda exc: errors.append(str(exc)))
+            page.on("console", lambda msg: errors.append(msg.text) if msg.type == "error" else None)
+
+            page.goto(APP_URL, wait_until="domcontentloaded")
+            page.wait_for_selector("#canvas", state="attached", timeout=10000)
+            page.wait_for_timeout(2000)
+
+            overlay_visible = page.locator("#error.visible").count() > 0
+            if overlay_visible:
+                raise AssertionError("Error overlay became visible")
+
+            # Clear any prior session history so this run's assertions are clean.
+            page.evaluate("() => localStorage.removeItem('neuro_weaver_training_history')")
+
+            # Switch to the Training tab.
+            page.click('.tab-btn[data-tab="tab-training"]')
+            page.wait_for_timeout(300)
+            assert page.locator("#tab-training.tab-pane.active").count() > 0, (
+                "Training tab did not become active"
+            )
+            assert page.locator("#training-course-select").count() > 0, (
+                "Training course picker missing"
+            )
+
+            # --- Full completion pass: Panic Recovery (key '7', 15s hold) ---
+            page.keyboard.press("7")
+            page.wait_for_timeout(3000)
+            objective_text = page.locator("#training-objective-label").inner_text()
+            assert "Panic Recovery" in objective_text, (
+                f"Expected Panic Recovery objective active, got: {objective_text!r}"
+            )
+
+            # Poll until the course completes (holdTime must accumulate for 15s
+            # inside the demo-driven calm band) or a generous timeout elapses.
+            deadline = time.time() + 25
+            completed = False
+            while time.time() < deadline:
+                history_raw = page.evaluate(
+                    "() => localStorage.getItem('neuro_weaver_training_history')"
+                )
+                history = json.loads(history_raw) if history_raw else []
+                if history and history[0].get("courseId") == "panic-recovery":
+                    completed = history[0]
+                    break
+                page.wait_for_timeout(1000)
+
+            assert completed, "Panic Recovery course never completed within the timeout"
+            assert completed["success"] is True, f"Panic Recovery did not succeed: {completed}"
+            assert completed["stars"] >= 1, f"Expected at least 1 star, got: {completed}"
+            page.screenshot(path=str(output_dir / "training_panic_recovery_complete.png"))
+
+            # --- Quick smoke pass for the other two built-in courses ---
+            for key, name in [("6", "Calm Focus"), ("8", "Flow Sustain")]:
+                page.keyboard.press(key)
+                page.wait_for_timeout(2500)
+                objective_text = page.locator("#training-objective-label").inner_text()
+                assert name in objective_text, (
+                    f"Expected {name} objective active after pressing '{key}', got: {objective_text!r}"
+                )
+                metric_val = page.evaluate(
+                    "() => document.getElementById('training-metric-val')?.textContent"
+                )
+                assert metric_val and "value:" in metric_val, (
+                    f"Expected live metric readout for {name}, got: {metric_val!r}"
+                )
+                page.screenshot(path=str(output_dir / f"training_{name.lower().replace(' ', '_')}.png"))
+
+            if errors:
+                hard_errors = [
+                    entry for entry in errors
+                    if "404" not in entry and "favicon" not in entry.lower()
+                ]
+                if hard_errors:
+                    raise AssertionError("Console/page errors detected:\n" + "\n".join(hard_errors[:8]))
+
+            browser.close()
+            print("Training mode verification passed.")
+    finally:
+        server.terminate()
+        try:
+            server.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            server.kill()
+
+
+if __name__ == "__main__":
+    try:
+        verify()
+    except Exception as exc:
+        print(f"verify_training failed: {exc}")
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Implements the "Neurofeedback (BCI) Training Mode" dream-log feature: a gamified mode where the player holds a simulated brain-state metric inside a target band for a sustained duration to complete an objective.

- **`TrainingEngine`** (`src/training-engine.js`) — simulated 0..1 metric samplers (`calm` from `renderer.params.stress`, `occipitalAlpha` from amplitude/smoothing, `flowResonance` from SynaptiX resonance stats / AudioReactor energy / flowSpeed), the `BUILTIN_COURSES` catalog, streak/drift-penalty/star scoring, and `localStorage` session history.
- **Three built-in courses**: Calm Focus, Panic Recovery, Flow Sustain (the last has 3 sequential checkpoints).
- **Routine integration**: `training_start` / `training_checkpoint` / `training_end` events (`src/routine-handlers/training.js`), with `training_end` auto-branching into a course's `onSuccessRoutine`/`onFailRoutine` sub-routine.
- **Training tab UI** (`src/ui/templates/tab-training.js`, `src/ui-training-panel.js`): course picker, progress ring, live metric gauge, streak/best readout, session history list.
- **Keyboard demo baseline**: digit keys `6`/`7`/`8` start each course and lerp the relevant renderer params straight into the target band, so every course is completable hands-free without any hardware or mouse interaction (used by the new `verification/verify_training.py`).
- **Docs**: `docs/training-mode.md` documents the course JSON schema, metrics, and scoring rules; `docs/ROADMAP.md`, `AGENTS.md`, and `.github/copilot-instructions.md` updated to reference the new module.
- **Fix**: adding a 7th tab overflowed `.tab-bar`'s fixed-width flex row, causing the whole `#controls` panel to horizontally scroll (and clip) when a far-right tab was focused. Added `flex-wrap: wrap` so the tab bar wraps onto additional rows instead.

## Test plan

- [x] `npm run build` succeeds
- [x] `verification/verify_training.py` passes locally (WebGL2 fallback): Training tab renders, all three courses show live progress, Panic Recovery runs to full completion with 3-star scoring recorded in `localStorage`
- [x] Manually screenshotted all three courses mid-session to confirm progress ring / metric gauge / band readout render correctly
- [x] Confirmed the tab-bar wrap fix doesn't regress the existing tabs (screenshotted the default Activity tab)
- [ ] CI (`verification/verify_suite.py`, now including `verify_training.py`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VHkYFt7MWNE2UYMMgNshf6)_