### PR TITLE
Implement visual cortex fatigue and neuroplasticity decay shaders

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -386,10 +386,11 @@
 - [x] Camera Camera Coordinates Map
 
 ## Phase 2.5 Extension: Neuroplasticity Decay
-- [ ] Implement detailed neuroplasticity decay shader variables.
+- [x] Implement detailed neuroplasticity decay shader variables.
 - [x] Implement `neuroplasticity_decay` event to visualize reduced neuroplasticity in simulated aging brains.
+- [x] Visual cortex fatigue (progressive blur in render pipeline).
 
 ## Dream Log
 - What if we visualized auditory hallucinations as rapid localized cortex flashes?
 
-* Idea: "What if we visualized visual cortex fatigue as progressive blur in the render pipeline?"
+* Idea: "What if we simulated hypothermia as reduced metabolic rate and frosty hues?"

--- a/src/brain-renderer.js
+++ b/src/brain-renderer.js
@@ -93,6 +93,8 @@ export class BrainRenderer {
             myelin_degradation: 0.0, // [V3.1] Connectome myelin loss visualization
             fluidActive: 0.0,
             immuneActivity: 0.0, // [Phase 6] Procedural Volumetric Fluid Dynamics
+            plasticityDecay: 0.0,
+            visualFatigue: 0.0,
             edgeDetection: 0.0, // Visual Cortex Edge Detection
             // Altitude/Hypoxia Simulation Parameters
             altitude: 0.0, // Altitude in meters (0-8000)

--- a/src/brain-renderer/uniforms.js
+++ b/src/brain-renderer/uniforms.js
@@ -91,8 +91,10 @@ export function applyUniformsMethods(Target) {
         const OFFSET_DECIMATION = 85;
         const OFFSET_PSYCHEDELIC = 86;
         const OFFSET_IMMUNE_ACTIVITY = 87;
+        const OFFSET_PLASTICITY_DECAY = 88;
+        const OFFSET_VISUAL_FATIGUE = 89;
 
-        const RENDER_UNIFORM_FLOAT_COUNT = 88;
+        const RENDER_UNIFORM_FLOAT_COUNT = 92;
         const uData = new Float32Array(RENDER_UNIFORM_FLOAT_COUNT);
         uData.set(mvp, OFFSET_MVP);
         uData.set(model, OFFSET_MODEL);
@@ -153,6 +155,8 @@ export function applyUniformsMethods(Target) {
         uData[OFFSET_DECIMATION] = this.params.decimation;
         uData[OFFSET_PSYCHEDELIC] = this.params.psychedelic || 0.0;
         uData[OFFSET_IMMUNE_ACTIVITY] = this.params.immuneActivity || 0.0;
+        uData[OFFSET_PLASTICITY_DECAY] = this.params.plasticityDecay || 0.0;
+        uData[OFFSET_VISUAL_FATIGUE] = this.params.visualFatigue || 0.0;
 
         if (!uniformLayoutChecked) {
             uniformLayoutChecked = true;
@@ -173,7 +177,8 @@ export function applyUniformsMethods(Target) {
                 tmsRadius: OFFSET_PAD3, edgeDetection: OFFSET_EDGE_DETECTION, pulseSaturation: OFFSET_PULSE_SATURATION,
                 trailLength: OFFSET_TRAIL_LENGTH, lesionCenter: OFFSET_LESION_CENTER, lesionActive: OFFSET_LESION_ACTIVE,
                 lesionRadius: OFFSET_LESION_RADIUS, decimation: OFFSET_DECIMATION, psychedelic: OFFSET_PSYCHEDELIC,
-                immuneActivity: OFFSET_IMMUNE_ACTIVITY,
+                immuneActivity: OFFSET_IMMUNE_ACTIVITY, plasticityDecay: OFFSET_PLASTICITY_DECAY,
+                visualFatigue: OFFSET_VISUAL_FATIGUE,
             }, RENDER_UNIFORM_FLOAT_COUNT);
             assertShaderUniformsMatch({
                 vertexShader, fragmentShader, fiberVertexShader, fiberFragmentShader,

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,7 @@ import { setupTrainingIntegration } from './main-training-integration.js';
 import { startMainUpdateLoop } from './main-update-loop.js';
 
 async function init() {
+    // [Neuro-Weaver] Initializing UI and backend connections
     mountControlsShell();
     initTabSwitching();
 

--- a/src/mini-routines/part2.js
+++ b/src/mini-routines/part2.js
@@ -510,6 +510,11 @@ export const MINI_ROUTINES_PART2 = {
         { time: 5.0, type: 'text', message: 'Network pruned.', duration: 2.0 },
         { time: 6.0, type: 'calm' }
     ],
+    '_': [ // Visual Cortex Fatigue Demo
+        { time: 0.0, type: 'text', message: 'Visual Cortex Fatigue Demo', duration: 2.0 },
+        { time: 0.0, type: 'visual_cortex_fatigue', intensity: 1.0, duration: 4.0 },
+        { time: 5.0, type: 'visual_cortex_fatigue', intensity: 0.0, duration: 4.0 }
+    ],
     'Q': [ // Neuroplasticity Sprouting
         { time: 0.0, type: 'text', message: 'Neuroplasticity: Forming New Connections', duration: 3.0 },
         { time: 0.0, type: 'style', value: 2 }, // Connectome

--- a/src/routine-handlers/narrative-flow.js
+++ b/src/routine-handlers/narrative-flow.js
@@ -216,6 +216,17 @@ export function registerNarrativeFlowHandlers(handlers, player) {
 
 
 
+    // [Phase 2.5] Visual Cortex Fatigue
+    handlers.set('visual_cortex_fatigue', (evt) => {
+        const duration = evt.duration || 5.0;
+        const ease = evt.ease || 'sineInOut';
+        const intensity = evt.intensity !== undefined ? evt.intensity : 1.0;
+        player.startLerp({ key: 'visualFatigue', value: intensity, duration: duration, ease: ease });
+        if (evt.message) {
+            player.executeEvent({ type: 'text', message: evt.message, duration: duration });
+        }
+    });
+
     // [Phase 10] Auditory Hallucinations
     handlers.set('auditory_hallucination', (evt) => {
         const flashes = evt.flashes || 10;
@@ -268,6 +279,7 @@ export function registerNarrativeFlowHandlers(handlers, player) {
         player.startLerp({ key: 'growth', value: 0.5, duration: duration, ease: ease });
         player.startLerp({ key: 'flowSpeed', value: 2.0, duration: duration, ease: ease });
         player.startLerp({ key: 'amplitude', value: 0.1, duration: duration, ease: ease });
+        player.startLerp({ key: 'plasticityDecay', value: 1.0, duration: duration, ease: ease });
 
         if (evt.message) {
             player.executeEvent({ type: 'text', message: evt.message, duration: duration });

--- a/src/routine-player.js
+++ b/src/routine-player.js
@@ -520,6 +520,7 @@ export class RoutinePlayer {
 
     // [Event Handling Requirement] The executeEvent switch statement must be extensible
     executeEvent(event) {
+        if (typeof event !== 'object') return; // [Neuro-Weaver] Ensure event object is valid
         if (!event || typeof event.type !== 'string') {
             console.warn("[Routine Engine] Cannot execute invalid event. Missing or invalid 'type':", event);
             return;

--- a/src/shaders/fiber.js
+++ b/src/shaders/fiber.js
@@ -52,6 +52,8 @@ struct Uniforms {
     decimation: f32,
     psychedelic: f32,
     immuneActivity: f32,
+    plasticityDecay: f32,
+    visualFatigue: f32,
 }
 
 struct FiberVertexInput {
@@ -196,7 +198,7 @@ fn main(input: FiberVertexInput) -> FiberVertexOutput {
     let myelin = clamp(input.fiberMeta.z, 0.0, 1.0);
     let segmentPhase = input.fiberMeta.w;
     let isAI = bundleId >= 100.0;
-    let degradation = clamp(uniforms.cortisol, 0.0, 1.0);
+    let degradation = clamp(uniforms.cortisol + uniforms.plasticityDecay, 0.0, 1.0);
     let effectiveMyelin = myelin * (1.0 - degradation * (1.0 - myelin));
     let hierarchy = clamp(radius * select(18.0, 48.0, isAI), 0.0, 1.0);
     let taper = clamp(1.0 - hierarchy * 0.45, 0.35, 1.0);
@@ -309,6 +311,8 @@ struct Uniforms {
     decimation: f32,
     psychedelic: f32,
     immuneActivity: f32,
+    plasticityDecay: f32,
+    visualFatigue: f32,
 }
 
 struct FiberFragmentInput {

--- a/src/shaders/post-pointcloud.js
+++ b/src/shaders/post-pointcloud.js
@@ -61,6 +61,8 @@ struct Uniforms {
     decimation: f32,
     psychedelic: f32,
     immuneActivity: f32,
+    plasticityDecay: f32,
+    visualFatigue: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 @group(0) @binding(1) var tDiffuse: texture_2d<f32>;
@@ -77,7 +79,7 @@ fn main(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
 
     // Calculate Circle of Confusion
     let coc = abs(depth - uniforms.focus);
-    let blurAmount = coc * uniforms.aperture * 10.0;
+    let blurAmount = coc * uniforms.aperture * 10.0 + uniforms.visualFatigue * 15.0;
 
     // Chromatic Aberration
     var offset = uniforms.aberration * 0.01;
@@ -227,6 +229,8 @@ struct Uniforms {
     decimation: f32,
     psychedelic: f32,
     immuneActivity: f32,
+    plasticityDecay: f32,
+    visualFatigue: f32,
 }
 
 struct VertexInput {
@@ -450,6 +454,8 @@ struct Uniforms {
     decimation: f32,
     psychedelic: f32,
     immuneActivity: f32,
+    plasticityDecay: f32,
+    visualFatigue: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 

--- a/src/shaders/soma.js
+++ b/src/shaders/soma.js
@@ -52,6 +52,8 @@ struct Uniforms {
     decimation: f32,
     psychedelic: f32,
     immuneActivity: f32,
+    plasticityDecay: f32,
+    visualFatigue: f32,
 }
 
 struct VertexInput {
@@ -179,6 +181,11 @@ fn main_soma(input: VertexInput) -> VertexOutput {
         scale *= max(0.0, decayFactor);
     }
 
+    if (uniforms.plasticityDecay > 0.0) {
+        let decayFactor = 1.0 - (uniforms.plasticityDecay * 0.5);
+        scale *= max(0.0, decayFactor);
+    }
+
     // Elongation for pyramidal / interneuron shape variation
     let theta = shapeSeed * 6.28318;
     let phi = shapeSeed * 12.566;
@@ -285,6 +292,8 @@ struct Uniforms {
     decimation: f32,
     psychedelic: f32,
     immuneActivity: f32,
+    plasticityDecay: f32,
+    visualFatigue: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 

--- a/src/shaders/spark-compute.js
+++ b/src/shaders/spark-compute.js
@@ -52,6 +52,8 @@ struct Uniforms {
     decimation: f32,
     psychedelic: f32,
     immuneActivity: f32,
+    plasticityDecay: f32,
+    visualFatigue: f32,
 }
 
 struct SparkInput {
@@ -245,6 +247,8 @@ struct Uniforms {
     decimation: f32,
     psychedelic: f32,
     immuneActivity: f32,
+    plasticityDecay: f32,
+    visualFatigue: f32,
 }
 
 struct SparkInput {
@@ -316,6 +320,8 @@ struct TensorParams {
     decimation: f32,
     psychedelic: f32,
     immuneActivity: f32,
+    plasticityDecay: f32,
+    visualFatigue: f32,
 }
 
 @group(0) @binding(0) var<storage, read_write> activityTensor: array<f32>;

--- a/src/shaders/surface.js
+++ b/src/shaders/surface.js
@@ -53,6 +53,8 @@ struct Uniforms {
     decimation: f32,
     psychedelic: f32,
     immuneActivity: f32,
+    plasticityDecay: f32,
+    visualFatigue: f32,
 }
 
 struct VertexInput {
@@ -213,6 +215,11 @@ fn main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> VertexOu
                 finalPos *= max(0.0, decayFactor);
             }
 
+            if (uniforms.plasticityDecay > 0.0) {
+                let erosion = uniforms.plasticityDecay * 0.15;
+                finalPos -= normalize(input.position) * erosion;
+            }
+
             // [Phase 2] Cognitive Stress Distortion
             if (uniforms.stress > 0.0) {
                 let noiseFreq = 15.0;
@@ -225,6 +232,11 @@ fn main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> VertexOu
                 // Decay structural integrity based on cortisol level (shrinks vertices inward, especially higher activity areas)
                 let decayErosion = uniforms.cortisol * 0.2 * (1.0 - activity);
                 finalPos -= normalize(input.position) * decayErosion;
+            }
+
+            if (uniforms.plasticityDecay > 0.0) {
+                let erosion = uniforms.plasticityDecay * 0.15;
+                finalPos -= normalize(input.position) * erosion;
             }
 
             // [Phase 6] Heavy Metal Structural Alteration
@@ -351,6 +363,8 @@ struct Uniforms {
     decimation: f32,
     psychedelic: f32,
     immuneActivity: f32,
+    plasticityDecay: f32,
+    visualFatigue: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 @group(0) @binding(1) var<storage, read> activityTensor: array<f32>;

--- a/src/shaders/uniform-layout.js
+++ b/src/shaders/uniform-layout.js
@@ -85,6 +85,8 @@ export const RENDER_UNIFORM_LAYOUT = [
     { name: 'decimation', type: 'f32' },
     { name: 'psychedelic', type: 'f32' },
     { name: 'immuneActivity', type: 'f32' },
+    { name: 'plasticityDecay', type: 'f32' },
+    { name: 'visualFatigue', type: 'f32' },
 ];
 
 /**

--- a/src/types.js
+++ b/src/types.js
@@ -54,6 +54,8 @@
  * @property {number} myelin_degradation - [V3.1] Connectome myelin loss (0-1).
  * @property {number} fluidActive - Procedural volumetric fluid dynamics blend (0-1).
  * @property {number} immuneActivity - [Phase 6] Immune cell migration activity (0-1).
+ * @property {number} plasticityDecay - [Phase 2.5] Neuroplasticity decay shader variable
+ * @property {number} visualFatigue - [Phase 2.5] Visual cortex fatigue / progressive blur
  * @property {number} edgeDetection - Visual cortex edge-detection filter blend (0-1).
  * @property {number} altitude - Simulated altitude in meters (0-8000).
  * @property {number} oxygenLevel - Oxygen saturation (1.0-0.3).

--- a/src/ui-legend-panel.js
+++ b/src/ui-legend-panel.js
@@ -68,6 +68,7 @@ export function setupLegendPanel() {
                 <div class="legend-item"><span class="legend-key">[</span><span>Binding Kinetics</span></div>
                 <div class="legend-item"><span class="legend-key">Q</span><span>Neuroplasticity</span></div>
                 <div class="legend-item"><span class="legend-key">}</span><span>Neuroplasticity Decay</span></div>
+                <div class="legend-item"><span class="legend-key">_</span><span>Visual Fatigue</span></div>
 
                 <div class="legend-item"><span class="legend-key">K</span><span>Memory Formation</span></div>
                 <div class="legend-item"><span class="legend-key">N</span><span>Myelin Degradation</span></div>


### PR DESCRIPTION
Implemented detailed neuroplasticity decay shader variables and added a visual cortex fatigue effect as a new Phase 2.5 Extension, bringing in an idea from the Dream Log. This allows dynamic morphing/blurring of the connectome visual based on simulated fatigue and aging.

---
*PR created automatically by Jules for task [6142610016010394964](https://jules.google.com/task/6142610016010394964) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added visual fatigue effects, including progressive blur and neural rendering degradation.
  - Added visual cortex fatigue controls to narrative routines and a dedicated demo shortcut.
  - Added visual fatigue to the keyboard shortcuts legend.
  - Expanded neuroplasticity decay effects across brain visualizations.

- **Bug Fixes**
  - Improved routine handling by safely ignoring invalid events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->