### PR TITLE
feat: implement spatial memory retrieval visualization

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -377,7 +377,12 @@
 *Idea:* "What if we visualized Serotonin levels as color shifts?"
 
 *Idea:* "What if we could simulate the interaction between Dopamine and Serotonin directly as color blending pathways?"
-*Idea:* "What if we visualized spatial memory retrieval as glowing breadcrumbs traveling backwards along the connectome fibers?"
+[x] "What if we visualized spatial memory retrieval as glowing breadcrumbs traveling backwards along the connectome fibers?"
 
 ### Phase 19: Dopamine Pathways Overlay
 - [x] **Dopamine Pathways:** Implement a task to visualize Dopamine pathways as glowing trails.
+
+### Phase 2.5 Extension: Spatial Memory Retrieval
+- [x] **Spatial Memory Retrieval:** Visualized spatial memory retrieval as glowing breadcrumbs traveling backwards along the connectome fibers, controlled via `spatial_memory` event.
+
+*Idea:* "What if we visualized the brain's default mode network transitioning into task-positive networks during problem-solving tasks?"

--- a/src/brain-renderer.js
+++ b/src/brain-renderer.js
@@ -97,6 +97,7 @@ export class BrainRenderer {
             plasticityDecay: 0.0,
             visualFatigue: 0.0,
             sensoryDeprivation: 0.0,
+            spatialMemory: 0.0,
             edgeDetection: 0.0, // Visual Cortex Edge Detection
             // Altitude/Hypoxia Simulation Parameters
             altitude: 0.0, // Altitude in meters (0-8000)

--- a/src/brain-renderer/uniforms.js
+++ b/src/brain-renderer/uniforms.js
@@ -94,6 +94,7 @@ export function applyUniformsMethods(Target) {
         const OFFSET_PLASTICITY_DECAY = 88;
         const OFFSET_VISUAL_FATIGUE = 89;
         const OFFSET_SENSORY_DEPRIVATION = 90;
+        const OFFSET_SPATIAL_MEMORY = 91;
 
         const RENDER_UNIFORM_FLOAT_COUNT = 92;
         const uData = new Float32Array(RENDER_UNIFORM_FLOAT_COUNT);
@@ -159,6 +160,7 @@ export function applyUniformsMethods(Target) {
         uData[OFFSET_PLASTICITY_DECAY] = this.params.plasticityDecay || 0.0;
         uData[OFFSET_VISUAL_FATIGUE] = this.params.visualFatigue || 0.0;
         uData[OFFSET_SENSORY_DEPRIVATION] = this.params.sensoryDeprivation || 0.0;
+        uData[OFFSET_SPATIAL_MEMORY] = this.params.spatialMemory || 0.0;
 
         // [SynaptiX Multi-Brain] Each avatar gets the same camera rotation but a
         // distinct local transform and tensor-only bind group.
@@ -197,7 +199,8 @@ export function applyUniformsMethods(Target) {
                 trailLength: OFFSET_TRAIL_LENGTH, lesionCenter: OFFSET_LESION_CENTER, lesionActive: OFFSET_LESION_ACTIVE,
                 lesionRadius: OFFSET_LESION_RADIUS, decimation: OFFSET_DECIMATION, psychedelic: OFFSET_PSYCHEDELIC,
                 immuneActivity: OFFSET_IMMUNE_ACTIVITY, plasticityDecay: OFFSET_PLASTICITY_DECAY,
-                visualFatigue: OFFSET_VISUAL_FATIGUE,
+                visualFatigue: OFFSET_VISUAL_FATIGUE, sensoryDeprivation: OFFSET_SENSORY_DEPRIVATION,
+                spatialMemory: OFFSET_SPATIAL_MEMORY,
             }, RENDER_UNIFORM_FLOAT_COUNT);
             assertShaderUniformsMatch({
                 vertexShader, fragmentShader, fiberVertexShader, fiberFragmentShader,

--- a/src/mini-routines/part2.js
+++ b/src/mini-routines/part2.js
@@ -583,3 +583,10 @@ export const MINI_ROUTINES_PART2 = {
         { time: 10.0, type: 'calm' }
     ],
 };
+
+MINI_ROUTINES_PART2['"'] = [ // [Phase 2.5] Spatial Memory Retrieval
+    { time: 0.0, type: 'text', message: 'Retrieving Spatial Memory...', duration: 4.0 },
+    { time: 0.0, type: 'spatial_memory', intensity: 1.0, duration: 4.0 },
+    { time: 4.0, type: 'spatial_memory', intensity: 0.0, duration: 2.0 },
+    { time: 4.0, type: 'text', message: 'Memory Consolidated', duration: 2.0 }
+];

--- a/src/routine-handlers/narrative-flow.js
+++ b/src/routine-handlers/narrative-flow.js
@@ -425,4 +425,17 @@ export function registerNarrativeFlowHandlers(handlers, player) {
             player.executeEvent({ type: 'text', message: evt.message, duration: duration });
         }
     });
+
+    handlers.set('spatial_memory', (evt) => {
+        const duration = evt.duration || 4.0;
+        const intensity = evt.intensity !== undefined ? evt.intensity : 1.0;
+
+        // Reverse flow speed and trigger spatial memory breadcrumbs
+        player.startLerp({ key: 'spatialMemory', value: intensity, duration: duration, ease: 'sineInOut' });
+        if (intensity > 0) { player.startLerp({ key: 'flowSpeed', value: -1.5 * intensity, duration: duration, ease: 'sineInOut' }); } else { player.startLerp({ key: 'flowSpeed', value: 1.0, duration: duration, ease: 'sineInOut' }); }
+
+        if (evt.message) {
+            player.executeEvent({ type: 'text', message: evt.message, duration: duration });
+        }
+    });
 }

--- a/src/shaders.js
+++ b/src/shaders.js
@@ -1144,9 +1144,14 @@ fn main(input: FiberFragmentInput) -> @location(0) vec4<f32> {
     let glowPulse = 0.6 + 0.4 * sin(uniforms.time * 3.0 + input.distToCenter * 6.0 + input.signal * 4.0);
     let emissive = input.color * (0.35 + input.signal * 0.9) * glowPulse * mix(1.0, 1.25, myelin);
     let reasoningWarm = vec3<f32>(1.0, 0.55, 0.15) * clamp(uniforms.connectomeVariant, 0.0, 1.0) * input.signal * 0.4;
+
+    // [Phase 2.5] Spatial Memory Retrieval - backwards traveling glowing breadcrumbs
+    let breadcrumbPhase = fract(input.distToCenter * 8.0 - uniforms.time * 2.5);
+    let breadcrumbGlow = smoothstep(0.8, 1.0, breadcrumbPhase) * uniforms.spatialMemory;
+    let breadcrumbColor = vec3<f32>(1.0, 0.9, 0.4) * breadcrumbGlow * 3.0;
     let glowLuma = max(emissive.r, max(emissive.g, emissive.b));
 
-    let finalRgb = diffuse * twistShade + highlight + activityGlow + avalancheColor + emissive + reasoningWarm + vec3<f32>(1.0, 0.95, 0.65) * resonance * 0.35;
+    let finalRgb = diffuse * twistShade + highlight + activityGlow + avalancheColor + emissive + reasoningWarm + breadcrumbColor + vec3<f32>(1.0, 0.95, 0.65) * resonance * 0.35;
     let alpha = clamp(0.18 + input.signal * 0.4 + ndotl * 0.16 + rim * 0.18 + anisotropic * 0.12 + glowLuma * 0.12, 0.12, 0.96) * ambientOcclusion * mix(0.82, 1.0, taper);
 
 

--- a/src/shaders/fiber.js
+++ b/src/shaders/fiber.js
@@ -55,6 +55,7 @@ struct Uniforms {
     plasticityDecay: f32,
     visualFatigue: f32,
     sensoryDeprivation: f32,
+    spatialMemory: f32,
 }
 
 struct FiberVertexInput {
@@ -324,6 +325,7 @@ struct Uniforms {
     plasticityDecay: f32,
     visualFatigue: f32,
     sensoryDeprivation: f32,
+    spatialMemory: f32,
 }
 
 struct FiberFragmentInput {
@@ -409,9 +411,14 @@ fn main(input: FiberFragmentInput) -> @location(0) vec4<f32> {
     let glowPulse = 0.6 + 0.4 * sin(uniforms.time * 3.0 + input.distToCenter * 6.0 + input.signal * 4.0);
     let emissive = input.color * (0.35 + input.signal * 0.9) * glowPulse * mix(1.0, 1.25, myelin);
     let reasoningWarm = vec3<f32>(1.0, 0.55, 0.15) * clamp(uniforms.connectomeVariant, 0.0, 1.0) * input.signal * 0.4;
+
+    // [Phase 2.5] Spatial Memory Retrieval - backwards traveling glowing breadcrumbs
+    let breadcrumbPhase = fract(input.distToCenter * 8.0 - uniforms.time * 2.5);
+    let breadcrumbGlow = smoothstep(0.8, 1.0, breadcrumbPhase) * uniforms.spatialMemory;
+    let breadcrumbColor = vec3<f32>(1.0, 0.9, 0.4) * breadcrumbGlow * 3.0;
     let glowLuma = max(emissive.r, max(emissive.g, emissive.b));
 
-    let finalRgb = diffuse * twistShade + highlight + activityGlow + avalancheColor + emissive + reasoningWarm + vec3<f32>(1.0, 0.95, 0.65) * resonance * 0.35;
+    let finalRgb = diffuse * twistShade + highlight + activityGlow + avalancheColor + emissive + reasoningWarm + breadcrumbColor + vec3<f32>(1.0, 0.95, 0.65) * resonance * 0.35;
     let alpha = clamp(0.18 + input.signal * 0.4 + ndotl * 0.16 + rim * 0.18 + anisotropic * 0.12 + glowLuma * 0.12, 0.12, 0.96) * ambientOcclusion * mix(0.82, 1.0, taper);
 
     return vec4<f32>(finalRgb, alpha);

--- a/src/shaders/post-pointcloud.js
+++ b/src/shaders/post-pointcloud.js
@@ -64,6 +64,7 @@ struct Uniforms {
     plasticityDecay: f32,
     visualFatigue: f32,
     sensoryDeprivation: f32,
+    spatialMemory: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 @group(0) @binding(1) var tDiffuse: texture_2d<f32>;
@@ -233,6 +234,7 @@ struct Uniforms {
     plasticityDecay: f32,
     visualFatigue: f32,
     sensoryDeprivation: f32,
+    spatialMemory: f32,
 }
 
 struct VertexInput {
@@ -459,6 +461,7 @@ struct Uniforms {
     plasticityDecay: f32,
     visualFatigue: f32,
     sensoryDeprivation: f32,
+    spatialMemory: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 

--- a/src/shaders/soma.js
+++ b/src/shaders/soma.js
@@ -55,6 +55,7 @@ struct Uniforms {
     plasticityDecay: f32,
     visualFatigue: f32,
     sensoryDeprivation: f32,
+    spatialMemory: f32,
 }
 
 struct VertexInput {
@@ -304,6 +305,7 @@ struct Uniforms {
     plasticityDecay: f32,
     visualFatigue: f32,
     sensoryDeprivation: f32,
+    spatialMemory: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 

--- a/src/shaders/spark-compute.js
+++ b/src/shaders/spark-compute.js
@@ -55,6 +55,7 @@ struct Uniforms {
     plasticityDecay: f32,
     visualFatigue: f32,
     sensoryDeprivation: f32,
+    spatialMemory: f32,
 }
 
 struct SparkInput {
@@ -251,6 +252,7 @@ struct Uniforms {
     plasticityDecay: f32,
     visualFatigue: f32,
     sensoryDeprivation: f32,
+    spatialMemory: f32,
 }
 
 struct SparkInput {
@@ -325,6 +327,7 @@ struct TensorParams {
     plasticityDecay: f32,
     visualFatigue: f32,
     sensoryDeprivation: f32,
+    spatialMemory: f32,
 }
 
 @group(0) @binding(0) var<storage, read_write> activityTensor: array<f32>;

--- a/src/shaders/surface.js
+++ b/src/shaders/surface.js
@@ -56,6 +56,7 @@ struct Uniforms {
     plasticityDecay: f32,
     visualFatigue: f32,
     sensoryDeprivation: f32,
+    spatialMemory: f32,
 }
 
 struct VertexInput {

--- a/src/shaders/uniform-layout.js
+++ b/src/shaders/uniform-layout.js
@@ -88,6 +88,7 @@ export const RENDER_UNIFORM_LAYOUT = [
     { name: 'plasticityDecay', type: 'f32' },
     { name: 'visualFatigue', type: 'f32' },
     { name: 'sensoryDeprivation', type: 'f32' },
+    { name: 'spatialMemory', type: 'f32' },
 ];
 
 /**

--- a/src/types.js
+++ b/src/types.js
@@ -56,6 +56,7 @@
  * @property {number} immuneActivity - [Phase 6] Immune cell migration activity (0-1).
  * @property {number} plasticityDecay - [Phase 2.5] Neuroplasticity decay shader variable
  * @property {number} visualFatigue - [Phase 2.5] Visual cortex fatigue / progressive blur
+ * @property {number} spatialMemory - [Phase 2.5] Spatial memory retrieval intensity
  * @property {number} edgeDetection - Visual cortex edge-detection filter blend (0-1).
  * @property {number} altitude - Simulated altitude in meters (0-8000).
  * @property {number} oxygenLevel - Oxygen saturation (1.0-0.3).

--- a/src/ui-legend-panel.js
+++ b/src/ui-legend-panel.js
@@ -121,6 +121,7 @@ export function setupLegendPanel() {
                 <div class="legend-item"><span class="legend-key">z</span><span>Default Mode</span></div>
                 <div class="legend-item"><span class="legend-key">Y</span><span>Smooth Easing</span></div>
                 <div class="legend-item"><span class="legend-key">~</span><span>Stroke Lesion</span></div>
+                <div class="legend-item"><span class="legend-key">"</span><span>Spatial Memory</span></div>
                 <div class="legend-item"><span class="legend-key">#</span><span>Psychedelic Trip</span></div>
             </div>
         </div>


### PR DESCRIPTION
Implemented Spatial Memory Retrieval visualization.

1.  **Uniforms and Shaders**: Added `spatialMemory: f32` to the `Uniforms` struct in all WGSL files, and defined its offset layout. Updated the fiber fragment shader to render backwards-traveling glowing breadcrumbs.
2.  **State and Handler**: Included `spatialMemory` property in `types.js` and `brain-renderer.js`. Implemented `spatial_memory` handler in `narrative-flow.js` that interpolates `spatialMemory` and modulates `flowSpeed` natively to create the flashback visual effect.
3.  **UI and Routine**: Bound `"` key to a new mini-routine demonstrating the effect, and updated `ui-legend-panel.js` to surface this.
4.  **Tracking**: Checked off the spatial memory Dream Log idea in `agent_plan.md` under Phase 2.5 Extension and added a new Default Mode Network transition idea.

---
*PR created automatically by Jules for task [9821070217462248048](https://jules.google.com/task/9821070217462248048) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a spatial memory retrieval experience with glowing, backward-moving breadcrumbs along brain fibers.
  * Added a guided routine with “Retrieving Spatial Memory…” and “Memory Consolidated” cues.
  * Added a “Spatial Memory” entry to the Advanced visualization legend.
* **Documentation**
  * Updated the development plan to record spatial memory retrieval as completed and formalize it as a Phase 2.5 extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->