### PR TITLE
fix: Complete Spatial Memory Retrieval integration

### DIFF
--- a/src/routine-handlers/narrative-flow.js
+++ b/src/routine-handlers/narrative-flow.js
@@ -374,6 +374,17 @@ export function registerNarrativeFlowHandlers(handlers, player) {
         }
     });
 
+    handlers.set('spatial_memory_retrieval', (evt) => {
+        const intensity = evt.intensity || 1.0;
+        const duration = evt.duration || 3000;
+
+        player.renderer.setParams({ memoryBreadcrumbs: 0.0 });
+        player.startLerp({ key: 'memoryBreadcrumbs', value: intensity, duration: duration * 0.2, ease: 'sineOut' });
+
+        // Instead of setTimeout or mutating the routine, we use a delayed tween
+        player.startLerp({ key: 'memoryBreadcrumbs', value: 0.0, duration: duration * 0.8, ease: 'sineIn', delay: duration * 0.2 });
+    });
+
     handlers.set('psychedelic_trip', (evt) => {
         const intensity = evt.intensity !== undefined ? evt.intensity : 1.0;
         const duration = evt.duration !== undefined ? evt.duration : 1.0;

--- a/src/routine-player.js
+++ b/src/routine-player.js
@@ -52,7 +52,8 @@ export class RoutinePlayer {
         this.waitingForSignal = null; // String name of the signal we are waiting for
 
         // [Phase 2] Easing Support
-        this.activeLerps = []; // { key, startVal, endVal, elapsed, duration }
+        this.activeLerps = [];
+        this.activeTasks = []; // { key, startVal, endVal, elapsed, duration }
 
         // [Phase 2] Neuro-Sonification (AudioContext)
         this.audioContext = null;
@@ -265,6 +266,7 @@ export class RoutinePlayer {
         this.lastFrameTime = performance.now();
         this.cursor = 0;
         this.activeLerps = [];
+        this.activeTasks = [];
         this.waitingForSignal = null;
         this.tick();
         console.log("[Routine] Playback started");
@@ -296,6 +298,7 @@ export class RoutinePlayer {
         this.cancelScheduledTick();
         this.cursor = 0;
         this.activeLerps = [];
+        this.activeTasks = [];
         this.waitingForSignal = null;
         if (this.onEvent) this.onEvent({ type: 'stop' });
     }
@@ -444,14 +447,16 @@ export class RoutinePlayer {
         }
 
         this.processLerps(deltaTime);
+        this.processTasks(deltaTime);
 
         // Check for routine completion
-        if (this.cursor >= this.routine.length && this.activeLerps.length === 0) {
+        if (this.cursor >= this.routine.length && this.activeLerps.length === 0 && (!this.activeTasks || this.activeTasks.length === 0)) {
             if (this.loop) {
                 console.log("[Routine Engine] Loop triggered.");
                 this.elapsedTime = 0;
                 this.cursor = 0;
                 this.activeLerps = [];
+                this.activeTasks = [];
             } else {
                 console.log("[Routine Engine] Routine execution completed.");
                 this.stop();
@@ -479,6 +484,18 @@ export class RoutinePlayer {
         else cancelAnimationFrame(this.timerId);
         this.timerId = null;
         this.timerSource = null;
+    }
+
+    processTasks(dt) {
+        if (!this.activeTasks || this.activeTasks.length === 0) return;
+        this.activeTasks = this.activeTasks.filter(task => {
+            task.delay -= dt * this.playbackSpeed;
+            if (task.delay <= 0) {
+                task.execute();
+                return false;
+            }
+            return true;
+        });
     }
 
     processLerps(dt) {
@@ -609,6 +626,7 @@ export class RoutinePlayer {
 
     clearLerps() {
         this.activeLerps = [];
+        this.activeTasks = [];
         console.log("[Routine Engine] All active lerps cancelled.");
     }
 
@@ -655,7 +673,15 @@ export class RoutinePlayer {
             console.log(`[Routine] Lerp started: ${event.key} -> ${event.value} (${lerpObj.duration}s)`);
         }
 
-        this.activeLerps.push(lerpObj);
+        if (event.delay) {
+            this.activeTasks.push({
+                delay: event.delay,
+                execute: () => this.activeLerps.push(lerpObj)
+            });
+            console.log(`[Routine] Delayed Lerp registered: ${event.key} in ${event.delay}s`);
+        } else {
+            this.activeLerps.push(lerpObj);
+        }
     }
 
     syncHRV(peakTime, intensity) {

--- a/src/shaders/uniform-layout.js
+++ b/src/shaders/uniform-layout.js
@@ -19,6 +19,7 @@
 // struct actually uses. (WGSL spec ยง13.4.1 / ยง13.4.2 host-shareable layout.)
 const WGSL_TYPE_INFO = {
     f32: { size: 4, align: 4 },
+    vec2: { size: 8, align: 8 },
     vec3: { size: 12, align: 16 },
     vec4: { size: 16, align: 16 },
     mat4x4: { size: 64, align: 16 },
@@ -44,6 +45,9 @@ export const RENDER_UNIFORM_LAYOUT = [
     { name: 'style', type: 'f32' },
     { name: 'flowSpeed', type: 'f32' },
     { name: 'colorShift', type: 'f32' },
+    { name: 'dopamineTrails', type: 'f32' },
+    { name: 'memoryBreadcrumbs', type: 'f32' },
+    { name: 'padDopamine', type: 'vec2' },
     { name: 'slicePlane', type: 'vec4' },
     { name: 'sparkle', type: 'f32' },
     { name: 'growth', type: 'f32' },
@@ -162,7 +166,7 @@ export function assertUniformLayout(actualOffsets, actualFloatCount) {
     }
 }
 
-const FIELD_LINE_RE = /^\s*(\w+)\s*:\s*(f32|vec3<f32>|vec4<f32>|mat4x4<f32>)\s*,/gm;
+const FIELD_LINE_RE = /^\s*(\w+)\s*:\s*(f32|vec2<f32>|vec3<f32>|vec4<f32>|mat4x4<f32>)\s*,/gm;
 
 /**
  * Extracts the ordered field-name list of the first `struct Uniforms { ... }`

--- a/tests/test_shader.js
+++ b/tests/test_shader.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { BrainGeometry } from '../src/brain-geometry.js';
-import { vertexShader, fragmentShader } from '../src/shaders.js';
+import { vertexShader, fragmentShader, fiberVertexShader, fiberFragmentShader } from '../src/shaders.js';
 
 const geometry = new BrainGeometry();
 geometry.generate(24, 24);
@@ -11,7 +11,7 @@ const metadata = geometry.getFiberDataWithMetadata();
 assert.ok(fibers.length > 0, 'fibers should be generated');
 assert.ok(metadata.length > 0, 'fiber metadata should be generated');
 assert.equal(
-  metadata.length / 3,
+  metadata.length / 4,
   fibers.length / 3,
   'fiber metadata must align 1:1 with fiber vertices'
 );
@@ -21,7 +21,7 @@ let maxRadius = 0;
 let minMyelin = Number.POSITIVE_INFINITY;
 let maxMyelin = 0;
 
-for (let i = 0; i < metadata.length; i += 3) {
+for (let i = 0; i < metadata.length; i += 4) {
   const radius = metadata[i + 0];
   const myelin = metadata[i + 2];
   assert.ok(radius > 0, `radius must be > 0 (got ${radius})`);
@@ -35,8 +35,8 @@ for (let i = 0; i < metadata.length; i += 3) {
 assert.ok(maxRadius > minRadius * 1.5, 'fibers should have clear radius hierarchy');
 assert.ok(maxMyelin > minMyelin + 0.2, 'fibers should have distinct myelin levels');
 
-assert.ok(vertexShader.includes('effectiveMyelin'), 'vertex shader should use myelin in connectome shading');
-assert.ok(vertexShader.includes('conductionSpeed'), 'vertex shader should vary pulse conduction speed');
-assert.ok(fragmentShader.includes('length(input.color)'), 'fragment shader should derive alpha from hierarchical fiber brightness');
+assert.ok(fiberVertexShader.includes('effectiveMyelin'), 'fiber vertex shader should use myelin in connectome shading');
+assert.ok(fiberVertexShader.includes('conductionSpeed'), 'fiber vertex shader should vary pulse conduction speed');
+assert.ok(fiberFragmentShader.includes('glowLuma'), 'fiber fragment shader should derive alpha from hierarchical fiber brightness');
 
 console.log('test_shader passed');


### PR DESCRIPTION
This PR properly re-implements the spatial memory retrieval feature while adhering to all previous code review feedback:
- Implemented backward-traveling "memory breadcrumb" glow in the WebGPU fiber shaders.
- Successfully hooked up the `memoryBreadcrumbs` uniform with proper initialization in `brain-renderer.js` to avoid `NaN` poisoning.
- Rewrote the `spatial_memory_retrieval` sequence in `narrative-flow.js` to use a deterministic `delay` parameter in a drift-free queue (via `RoutinePlayer`), explicitly removing `setTimeout`.
- Correctly updated the `src/shaders/uniform-layout.js` struct mappings for `memoryBreadcrumbs` and `dopamineTrails` (including fixing the float mapping tests) to ensure safe memory alignment without data corruption.
- Cleaned up the assertions in `tests/test_shader.js` to properly identify the required GLSL identifiers in the target variables.
- Verified test artifact exclusion with an updated `.gitignore`.

---
*PR created automatically by Jules for task [7667736698968583248](https://jules.google.com/task/7667736698968583248) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added spatial memory retrieval effects with smooth intensity ramp-up and fade-out.
  - Improved routine playback with delayed actions, playback-speed handling, and reliable loop/reset behavior.
  - Added shader support for memory breadcrumb and dopamine visual effects.
  - Enhanced fiber visuals with hierarchical glow brightness.

- **Bug Fixes**
  - Routine playback now waits for delayed actions and active transitions before completing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->