### PR TITLE
Implement Dynamic Particle Speed Modulation

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -83,7 +83,7 @@
 - [x] **Respiration Simulation:** Implement a respiration event type that links to heartbeat and modulates flow speed and overall scene intensity.
 - [x] **Interactive Timeline Editor:** Created a visual, drag-and-drop timeline editor for sequence building instead of writing JSON directly.
 - [x] **Routine Markers:** Add a 'marker' event type to log specific points in the timeline for external syncing.
-- [ ] **Dynamic Particle Speed Modulation:** Add support for routines to dynamically control individual particle traversal speed in addition to global flow speed.
+- [x] **Dynamic Particle Speed Modulation:** Add support for routines to dynamically control individual particle traversal speed in addition to global flow speed.
 ### Phase 3: "Brain DJ" Mode (Live Performance)
 - [x] **Dynamic Environment Reactions:** Allow respiration rate to dynamically react to visual stimuli or events.
 - [x] **Keyboard Triggers:** Bind number keys (1-9) to specific mini-routines (e.g., Press '1' for "Sudden Surprise", '2' for "Calm Down").
@@ -434,3 +434,6 @@
 * [2026-08-09] - Completed Routine Logic Refactor. Ensured `tick()` uses `performance.now()`, `executeEvent` uses switch, and WebGPU degrades safely. Added tasks for Interpolation and Camera Maps, and Serotonin to Dream Log.
 
 *Idea:* "What if we visualized Serotonin levels as color shifts?"
+- [ ] **Parameter Interpolation/Easing:** Enhance region injection feedback parameters with smooth interpolation.
+- [ ] **Camera Coordinates Map:** Define explicit regions for better camera angles.
+*Idea:* "What if we visualized neurotransmitters using distinct particle shapes and unique traversal algorithms?"

--- a/src/brain-renderer.js
+++ b/src/brain-renderer.js
@@ -103,6 +103,7 @@ export class BrainRenderer {
             sensoryDeprivation: 0.0,
             spatialMemory: 0.0,
             apoptosis: 0.0,
+            particleSpeed: 1.0,
             edgeDetection: 0.0, // Visual Cortex Edge Detection
             pulseSaturation: 1.0,
             trailLength: 1.0,
@@ -946,6 +947,7 @@ export class BrainRenderer {
         const OFFSET_SENSORYDEPRIVATION = 94;
         const OFFSET_SPATIALMEMORY = 95;
         const OFFSET_APOPTOSIS = 96;
+        const OFFSET_PARTICLESPEED = 97;
 
         const RENDER_UNIFORM_FLOAT_COUNT = 100;
         const uData = new Float32Array(RENDER_UNIFORM_FLOAT_COUNT);
@@ -1014,6 +1016,7 @@ export class BrainRenderer {
         uData[OFFSET_SENSORYDEPRIVATION] = this.params.sensoryDeprivation;
         uData[OFFSET_SPATIALMEMORY] = this.params.spatialMemory;
         uData[OFFSET_APOPTOSIS] = this.params.apoptosis;
+        uData[OFFSET_PARTICLESPEED] = this.params.particleSpeed ?? 1.0;
 
         this.device.queue.writeBuffer(this.uniformBuffer, 0, uData);
         

--- a/src/mini-routines/part2.js
+++ b/src/mini-routines/part2.js
@@ -637,3 +637,11 @@ MINI_ROUTINES_PART2['$'] = [ // [Phase 2.5] Dynamic Seasonal Lighting Simulation
     { time: 12.0, type: 'lerp', key: 'flowSpeed', value: 0.5, duration: 4.0, ease: 'sineInOut' },
     { time: 16.0, type: 'text', message: 'SEASONAL CYCLE COMPLETE', duration: 2.0 }
 ];
+
+MINI_ROUTINES_PART2['\\'] = [
+    { time: 0.0, type: 'text', message: 'DYNAMIC PARTICLE SPEED MODULATION', duration: 3.0 },
+    { time: 0.0, type: 'lerp', key: 'particleSpeed', path: [1.0, 10.0], duration: 4.0, ease: 'sineInOut' },
+    { time: 4.0, type: 'lerp', key: 'particleSpeed', path: [10.0, 0.1], duration: 4.0, ease: 'sineInOut' },
+    { time: 8.0, type: 'lerp', key: 'particleSpeed', path: [0.1, 1.0], duration: 4.0, ease: 'sineInOut' },
+    { time: 12.0, type: 'text', message: 'ROUTINE COMPLETE', duration: 2.0 }
+];

--- a/src/shaders/fiber.js
+++ b/src/shaders/fiber.js
@@ -58,6 +58,7 @@ struct Uniforms {
     sensoryDeprivation: f32,
     spatialMemory: f32,
     apoptosis: f32,
+    particleSpeed: f32,
 }
 
 struct FiberVertexInput {
@@ -365,6 +366,7 @@ struct Uniforms {
     sensoryDeprivation: f32,
     spatialMemory: f32,
     apoptosis: f32,
+    particleSpeed: f32,
 }
 
 struct FiberFragmentInput {

--- a/src/shaders/post-pointcloud.js
+++ b/src/shaders/post-pointcloud.js
@@ -67,6 +67,7 @@ struct Uniforms {
     sensoryDeprivation: f32,
     spatialMemory: f32,
     apoptosis: f32,
+    particleSpeed: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 @group(0) @binding(1) var tDiffuse: texture_2d<f32>;
@@ -239,6 +240,7 @@ struct Uniforms {
     sensoryDeprivation: f32,
     spatialMemory: f32,
     apoptosis: f32,
+    particleSpeed: f32,
 }
 
 struct VertexInput {
@@ -468,6 +470,7 @@ struct Uniforms {
     sensoryDeprivation: f32,
     spatialMemory: f32,
     apoptosis: f32,
+    particleSpeed: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 

--- a/src/shaders/soma.js
+++ b/src/shaders/soma.js
@@ -58,6 +58,7 @@ struct Uniforms {
     sensoryDeprivation: f32,
     spatialMemory: f32,
     apoptosis: f32,
+    particleSpeed: f32,
 }
 
 struct VertexInput {
@@ -319,6 +320,7 @@ struct Uniforms {
     sensoryDeprivation: f32,
     spatialMemory: f32,
     apoptosis: f32,
+    particleSpeed: f32,
 }
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 

--- a/src/shaders/spark-compute.js
+++ b/src/shaders/spark-compute.js
@@ -58,6 +58,7 @@ struct Uniforms {
     sensoryDeprivation: f32,
     spatialMemory: f32,
     apoptosis: f32,
+    particleSpeed: f32,
 }
 
 struct SparkInput {
@@ -145,7 +146,7 @@ fn main(input: SparkInput) -> SparkOutput {
 
     let localActivity = sampleSmoothedVoxelValue(anchor);
     let pulseSpeed = uniforms.flowSpeed * mix(0.55, 1.25, localActivity + uniforms.fluidActive * 0.2);
-    let travel = (fract(uniforms.time * pulseSpeed * speedMul + input.anchorPhase.w + bundleId * 0.071) - 0.5);
+    let travel = (fract(uniforms.time * pulseSpeed * speedMul * uniforms.particleSpeed + input.anchorPhase.w + bundleId * 0.071) - 0.5);
     let trailScale = mix(0.10, 0.34, localActivity) * mix(0.8, 1.25, strength) * uniforms.trailLength;
     let center = anchor + tangent * (travel * trailScale);
 
@@ -257,6 +258,7 @@ struct Uniforms {
     sensoryDeprivation: f32,
     spatialMemory: f32,
     apoptosis: f32,
+    particleSpeed: f32,
 }
 
 struct SparkInput {
@@ -333,6 +335,7 @@ struct TensorParams {
     sensoryDeprivation: f32,
     spatialMemory: f32,
     apoptosis: f32,
+    particleSpeed: f32,
 }
 
 @group(0) @binding(0) var<storage, read_write> activityTensor: array<f32>;

--- a/src/shaders/surface.js
+++ b/src/shaders/surface.js
@@ -59,6 +59,7 @@ struct Uniforms {
     sensoryDeprivation: f32,
     spatialMemory: f32,
     apoptosis: f32,
+    particleSpeed: f32,
 }
 
 struct VertexInput {

--- a/src/ui-legend-panel.js
+++ b/src/ui-legend-panel.js
@@ -84,6 +84,7 @@ export function setupLegendPanel() {
                 <div class="legend-item"><span class="legend-key">&lt;</span><span>Hypothermia</span></div>
                 <div class="legend-item"><span class="legend-key">|</span><span>Env. Noise</span></div>
                 <div class="legend-item"><span class="legend-key">&amp;</span><span>Drug Delivery</span></div>
+                <div class="legend-item"><span class="legend-key">\</span><span>Particle Speed</span></div>
 
             </div>
         </div>


### PR DESCRIPTION
This PR implements the "Dynamic Particle Speed Modulation" task requested from `agent_plan.md`. It separates the visual speed of particles traveling along fiber paths from the global mesh flow speed. The `particleSpeed` uniform has been introduced (offset 97), synchronized into all WebGPU shader definitions, and utilized in `spark-compute.js`. A new UI shortcut (`\`) runs a mini-routine to demonstrate dynamic particle speed fading in and out. Verification tests complete and pass.

---
*PR created automatically by Jules for task [5998989087473400940](https://jules.google.com/task/5998989087473400940) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Particle Speed control that dynamically accelerates, decelerates, and restores particle movement.
  * Added the `\` shortcut to activate the particle-speed modulation routine.
  * Added a Systems legend entry identifying the new shortcut.
* **Documentation**
  * Updated the development plan to reflect completed particle-speed work and upcoming improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->