### PR TITLE
feat: Serotonin Color Shift Routine & Timeline Architecture

### DIFF
--- a/agent_plan.md
+++ b/agent_plan.md
@@ -13,6 +13,7 @@
 - [x] **"Deep Thought" Script:** Hardcode the demo routine (Organic -> Visual Input -> Connectome Processing -> Heatmap Aftermath).
 - [x] **Playback UI:** Add a "Run Sequence" button and a transport clock (Play/Stop/Loop) to the DOM.
 ### Phase 2: Advanced Choreography
+- [x] **Serotonin Color Shift Feature:** Implemented and wired the Serotonin color shift routine to key 4 and updated the UI legend.
 - [x] **Routine Logic & Extensibility Refactor:** Ensure `tick()` loop uses `performance.now()`, `executeEvent` is extensible, and WebGPU context gracefully degrades.
 
 - [x] **Parameter Interpolation/Easing:** Ensure routines have smooth interpolation.
@@ -189,6 +190,7 @@
 - [x] **Psychedelic Visuals Offset Fix:** Corrected uniform offset issues in `src/brain-renderer.js` to include missing uniforms like `psychedelic` and restored `dopamineTrails` struct alignment as demanded by the updated WGSL structural layout, restoring the `psychedelic_trip` functionality.
 
 ## 🧪 "Dream" Log (Future Concepts)
+* *Idea:* "What if we visualized Serotonin levels as color shifts?"
 * *Idea:* "What if we mapped real-time geographic data (like population density or traffic) to localized structural density and glow intensity in the tensor volume?"
 * [x] "What if we visualize immune cell migration as particle streams during an inflammatory response?"
 * *Idea:* "What if we visualize psychedelic experiences as morphing geometric structures in the tensor volume?" (Implemented as Phase 2.5 Extension - Psychedelic Visuals)"

--- a/src/main-routine-engine.js
+++ b/src/main-routine-engine.js
@@ -286,7 +286,7 @@ export function setupRoutineEngine(renderer, canvas, modeSelector, rendererInfo)
         const typing = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || (e.target && e.target.isContentEditable);
         if (!typing && !e.ctrlKey && !e.metaKey && !e.altKey && e.key >= '1' && e.key <= '5') {
             modeSelector.applyStyle(parseFloat(e.key) - 1.0);
-            return;
+            // Allow execution to continue so mapped mini-routines (like '4' for Serotonin) can run
         }
 
         let matchedRoutine = null;

--- a/src/main.js
+++ b/src/main.js
@@ -40,9 +40,10 @@ async function init() {
         const { renderer, rendererInfo } = await setupRendererBackend(canvas);
         const modeSelector = setupModeSelector(renderer);
 
-        // [Neuro-Script Cycle] setupRoutineEngine returns RoutinePlayer and AudioReactor instances.
+        // Initialize Routine Engine subsystems (RoutinePlayer, AudioReactor).
+        // Safely injected without breaking existing renderer initialization flow.
         const { player, audioReactor } = setupRoutineEngine(renderer, canvas, modeSelector, rendererInfo);
-        if (!player) console.warn('[Neuro-Script Cycle] RoutinePlayer failed to initialize.'); // [Neuro-Script Cycle] Verified init flow dependencies.
+        if (!player) console.warn('[Routine Engine] RoutinePlayer failed to initialize.');
 
         setupLegendPanel();
         const legendPanel = document.getElementById('legend-panel');

--- a/src/routine-handlers/neuromodulators.js
+++ b/src/routine-handlers/neuromodulators.js
@@ -13,24 +13,11 @@ export function registerNeuromodulatorsHandlers(handlers, player) {
         // Smoothly fade back after full surge is reached
         if (duration > 0) {
             const ease = evt.ease || 'sineInOut';
+            const delay = 2.0; // Wait for the initial surge to complete before fading out
 
-            // Keep chronological ordering for reverting the values back to normal
-            if (player.routine) {
-                const revertTime = player.elapsedTime + 2.0;
-
-                const revertEvents = [
-                    { time: revertTime, type: 'lerp', key: 'colorShift', value: 0.0, duration: duration, ease: ease },
-                    { time: revertTime, type: 'lerp', key: 'flowSpeed', value: 4.0, duration: duration, ease: 'quadOut' },
-                    { time: revertTime, type: 'lerp', key: 'fluidActive', value: 0.0, duration: duration, ease: ease }
-                ];
-
-                let insertIdx = player.currentEventIndex ?? player.cursor;
-                while (insertIdx < player.routine.length && player.routine[insertIdx].time < revertTime) {
-                    insertIdx++;
-                }
-
-                player.routine.splice(insertIdx, 0, ...revertEvents);
-            }
+            player.startLerp({ key: 'colorShift', value: 0.0, duration: duration, ease: ease, delay: delay });
+            player.startLerp({ key: 'flowSpeed', value: 4.0, duration: duration, ease: 'quadOut', delay: delay });
+            player.startLerp({ key: 'fluidActive', value: 0.0, duration: duration, ease: ease, delay: delay });
         }
     });
 

--- a/src/routine-player.js
+++ b/src/routine-player.js
@@ -14,10 +14,14 @@ import { parseRoutineCSV } from './routine-csv.js';
 import { buildProceduralRoutine } from './routine-procedural.js';
 
 export class RoutinePlayer {
-    // Extensible timeline sequencer implementing drift-free tick(), robust executeEvent,
-    // and WebGPU context loss degradation safety.
+    /**
+     * Extensible timeline sequencer.
+     * Architectural Features:
+     * - Timing: Uses performance.now() and delta-time compensation to ensure drift-free sequencing.
+     * - Extensibility: executeEvent() resolves variables dynamically and dispatches to a Map of registered handlers, with a switch fallback.
+     * - Safety: Tick loop degrades gracefully and halts execution if WebGPU context is lost or renderer is destroyed.
+     */
     constructor(renderer, regionMap, cameraMap) {
-        // Routine Engine logic verified in this cycle.
         // Expects BrainRenderer instance.
         this.renderer = renderer;
         this.regions = regionMap || {}; // Maps names like 'frontal' to [x,y,z]

--- a/src/shaders.js
+++ b/src/shaders.js
@@ -437,6 +437,12 @@ fn main(input: VertexInput, @builtin(vertex_index) vertexIndex: u32) -> VertexOu
 
             finalColor = vec3<f32>(0.2, 0.6, 1.0);
 
+            // Explicit Shader integration for Serotonin color shift
+            if (uniforms.colorShift > 0.0) {
+                let warmShift = vec3<f32>(1.0, 0.7, 0.2); // Warm gold/orange for Serotonin
+                finalColor = mix(finalColor, warmShift, uniforms.colorShift);
+            }
+
             // Style 1 (Cyber): Digital Grid
             if (uniforms.style > 0.5 && uniforms.style < 1.5) {
                 finalColor = vec3<f32>(0.0, 0.9, 0.5);

--- a/src/ui-legend-panel.js
+++ b/src/ui-legend-panel.js
@@ -41,6 +41,7 @@ export function setupLegendPanel() {
             <div class="legend-row">
                 <div class="legend-item"><span class="legend-key">UI</span><span>Neuromodulator Panel</span></div>
                 <div class="legend-item"><span class="legend-key">d</span><span>Dopamine</span></div>
+                <div class="legend-item"><span class="legend-key">4</span><span>Serotonin Surge</span></div>
                 <div class="legend-item"><span class="legend-key">e</span><span>Endorphin</span></div>
                 <div class="legend-item"><span class="legend-key">y</span><span>Oxytocin</span></div>
                 <div class="legend-item"><span class="legend-key">r</span><span>Acetylcholine</span></div>


### PR DESCRIPTION
Implemented the Serotonin Color Shift feature for the Neuro-Script Engine. Features dynamic WebGPU shader integration to alter structural color paths dynamically based on serotonin values. Wired cleanly via an extensible Routine event (`serotonin`) with robust `startLerp` timeline modifications, mapped out to hotkey `4`, and added to the UI legend. Also documented the existing robust architectural integration for drift-free timing.

---
*PR created automatically by Jules for task [92280790064187594](https://jules.google.com/task/92280790064187594) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Serotonin Surge” shortcut on key `4`.
  * Serotonin effects now create warm gold/orange color shifts in ghost mode.
  * Numeric style shortcuts now trigger their associated routines correctly.

* **Bug Fixes**
  * Improved scheduling of serotonin fade-back effects for smoother transitions.

* **Documentation**
  * Updated the shortcut legend and development notes for the new effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->