### PR TITLE
Fix WGSL reserved keyword and unbound 'params' region-physics bug

### DIFF
--- a/src/shaders/fiber.js
+++ b/src/shaders/fiber.js
@@ -98,12 +98,12 @@ struct FiberVertexOutput {
 @group(0) @binding(3) var<storage, read> fiberDirections: array<vec4<f32>>;
 @group(0) @binding(4) var<uniform> pathwayState: PathwayState;
 
-fn getPathwayEmission(meta: vec4<f32>, position: vec3<f32>) -> f32 {
-    if (meta.x <= 0.0 || abs(meta.x - pathwayState.control.x) > 0.25 || pathwayState.control.w > 0.5) {
+fn getPathwayEmission(pathwayMeta: vec4<f32>, position: vec3<f32>) -> f32 {
+    if (pathwayMeta.x <= 0.0 || abs(pathwayMeta.x - pathwayState.control.x) > 0.25 || pathwayState.control.w > 0.5) {
         return 0.0;
     }
-    let routeProgress = clamp(meta.z, 0.0, 1.0);
-    let selectionWeight = clamp(meta.w, 0.0, 1.0);
+    let routeProgress = clamp(pathwayMeta.z, 0.0, 1.0);
+    let selectionWeight = clamp(pathwayMeta.w, 0.0, 1.0);
     let head = clamp(1.0 - abs(routeProgress - pathwayState.control.y) / 0.12, 0.0, 1.0);
     let behind = pathwayState.control.y - routeProgress;
     var tail = 0.0;
@@ -184,7 +184,7 @@ fn sampleFiberCoupledSignal(worldPos: vec3<f32>, tangent: vec3<f32>, isAI: bool)
 
 fn calculateSignalFlow(startPos: vec3<f32>, endPos: vec3<f32>, time: f32, speed: f32, segmentPhase: f32, flowBias: f32, myelin: f32, radius: f32, bundleId: f32) -> f32 {
     let midpoint = mix(startPos, endPos, 0.5);
-    let region = getRegionPhysics(midpoint, uniforms.style);
+    let region = getRegionPhysics(midpoint, uniforms.style, vec4<f32>(0.96, 0.1, 0.0, 0.0), vec4<f32>(1.0, 1.0, 1.0, 1.0));
     let diffusionNorm = clamp(region.y / 0.15, 0.0, 1.0);
     var travel = fract(time * speed + segmentPhase + bundleId * 0.031);
     if (flowBias < -0.1) {
@@ -256,7 +256,7 @@ fn main(input: FiberVertexInput) -> FiberVertexOutput {
     let tractCoverage = coupledSignal.y;
     let tractAlignment = coupledSignal.z;
     let midpoint = mix(input.fiberStart, input.fiberEnd, 0.5);
-    let flowBias = getRegionPhysics(midpoint, uniforms.style).z;
+    let flowBias = getRegionPhysics(midpoint, uniforms.style, vec4<f32>(0.96, 0.1, 0.0, 0.0), vec4<f32>(1.0, 1.0, 1.0, 1.0)).z;
     let conductionBoost = 1.0 + uniforms.fiberCoupling * (0.25 + tractCoverage * 0.45 + tractAlignment * 0.35);
     let conductionSpeed = uniforms.flowSpeed * select(1.0, 2.35, isAI) * (0.45 + effectiveMyelin * 1.65 + radius * 18.0) * conductionBoost;
     let signalStrength = calculateSignalFlow(input.fiberStart, input.fiberEnd, uniforms.time, conductionSpeed, segmentPhase, flowBias, effectiveMyelin, radius, bundleId);

--- a/src/shaders/shared.js
+++ b/src/shaders/shared.js
@@ -26,16 +26,20 @@ const HELPERS = `
     // Returns vec3(decay, diffusion, flowBias)
     // [Neuro-Weaver] Defines anatomical zones: Frontal, Occipital, Temporal, Parietal
     // With regional sensitivity to hypoxia
-    fn getRegionPhysics(worldPosition: vec3<f32>, style: f32) -> vec3<f32> {
-        var decay = params.neuroPhysics.x; // Default from profile
-        var diffusion = params.neuroPhysics.y;
+    // neuroPhysics: x=baseline decay, y=baseline diffusion (defaults 0.96 / 0.1 when the caller
+    // has no per-profile override). neuroRetention: per-region blend weight (x=frontal,
+    // y=occipital, z=temporal, w=parietal) toward that region's target decay/diffusion; pass
+    // vec4<f32>(1.0) for full override (matches the original hardcoded region values).
+    fn getRegionPhysics(worldPosition: vec3<f32>, style: f32, neuroPhysics: vec4<f32>, neuroRetention: vec4<f32>) -> vec3<f32> {
+        var decay = neuroPhysics.x; // Default from profile
+        var diffusion = neuroPhysics.y;
         var flowBias = 0.0;
         var oxygenSensitivity = 1.0; // Regional vulnerability to hypoxia
 
         // Frontal Lobe: High retention for complex thought, MOST vulnerable to hypoxia
         if (worldPosition.z > 0.5) {
-            decay = mix(decay, 0.998, params.neuroRetention.x);
-            diffusion = mix(diffusion, 0.15, params.neuroRetention.x);
+            decay = mix(decay, 0.998, neuroRetention.x);
+            diffusion = mix(diffusion, 0.15, neuroRetention.x);
             flowBias = -1.0;
             oxygenSensitivity = 1.8; // Executive function degrades first
         }
@@ -43,18 +47,18 @@ const HELPERS = `
         // [Scientific Fix] Occipital is NOT particularly resistant - it's at terminal
         // PCA branches (watershed zone) and can be vulnerable to hypoxia
         else if (worldPosition.z < -0.5) {
-            decay = mix(decay, 0.92, params.neuroRetention.y);
-            diffusion = mix(diffusion, 0.04, params.neuroRetention.y);
+            decay = mix(decay, 0.92, neuroRetention.y);
+            diffusion = mix(diffusion, 0.04, neuroRetention.y);
             oxygenSensitivity = 1.0; // Neutral - not resistant, at watershed zone
         }
         // Temporal / Parietal logic...
         else if (abs(worldPosition.x) > 0.5) {
-            decay = mix(decay, 0.95, params.neuroRetention.z); // Using temporal bias
-            diffusion = mix(diffusion, 0.08, params.neuroRetention.z);
+            decay = mix(decay, 0.95, neuroRetention.z); // Using temporal bias
+            diffusion = mix(diffusion, 0.08, neuroRetention.z);
             flowBias = 0.5;
             oxygenSensitivity = 1.2;
         } else {
-            decay = mix(decay, 0.96, params.neuroRetention.w); // Parietal/center bias
+            decay = mix(decay, 0.96, neuroRetention.w); // Parietal/center bias
         }
 
         return vec3<f32>(decay, diffusion, flowBias);

--- a/src/shaders/spark-compute.js
+++ b/src/shaders/spark-compute.js
@@ -399,7 +399,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
     let worldPosition = indexToWorld(index, dim);
     let normalizedPosition = clamp((worldPosition / BRAIN_RANGE) * 0.5 + 0.5, vec3<f32>(0.0), vec3<f32>(1.0));
 
-    let physics = getRegionPhysics(worldPosition, params.style);
+    let physics = getRegionPhysics(worldPosition, params.style, params.neuroPhysics, params.neuroRetention);
     var decay = physics.x;
     var diffusion = physics.y;
     let flowBias = physics.z;
@@ -615,7 +615,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
         let aiVal = sampleAIActivation(worldPosition, dim);
         let aiEnergy = aiVal * params.aiInfluence;
         if (aiEnergy > 0.0005 || val > 0.0005) {
-            let aiRegion = getRegionPhysics(worldPosition, 1.0);
+            let aiRegion = getRegionPhysics(worldPosition, 1.0, params.neuroPhysics, params.neuroRetention);
             let aiDiffusionBias = clamp(aiRegion.y / 0.15, 0.0, 1.0);
             let aiGeometricDecay = mix(1.18, 0.86, aiDiffusionBias);
             let aiSparsity = smoothstep(0.14, 0.82, aiVal);

--- a/src/shaders/surface.js
+++ b/src/shaders/surface.js
@@ -111,7 +111,7 @@ fn sampleSmoothedAIVoxelValue(worldPos: vec3<f32>) -> f32 {
 
 fn calculateSignalFlow(startPos: vec3<f32>, endPos: vec3<f32>, time: f32, speed: f32, segmentPhase: f32, flowBias: f32, myelin: f32, radius: f32, bundleId: f32) -> f32 {
     let midpoint = mix(startPos, endPos, 0.5);
-    let region = getRegionPhysics(midpoint, uniforms.style);
+    let region = getRegionPhysics(midpoint, uniforms.style, vec4<f32>(0.96, 0.1, 0.0, 0.0), vec4<f32>(1.0, 1.0, 1.0, 1.0));
     let diffusionNorm = clamp(region.y / 0.15, 0.0, 1.0);
     var travel = fract(time * speed + segmentPhase + bundleId * 0.031);
 


### PR DESCRIPTION
## Summary

Fixes the WGSL compile failures reported from `test.1ink.us/brain-viz/` (30 Aug 2026):

```
WGSL:270  'meta' is a reserved keyword
  fn getPathwayEmission(meta: vec4<f32>, ...)
WGSL:22   unresolved value 'params'
  var decay = params.neuroPhysics.x
CreateShaderModule / CreateRenderPipeline invalid
```

- `src/shaders/fiber.js`: `getPathwayEmission(meta: vec4<f32>, ...)` used `meta`, a reserved WGSL identifier, which fails shader module compilation. Renamed to `pathwayMeta` (this is the fiber pipeline actually used at runtime — wired up via `core-methods.js`/`uniforms.js` — not the legacy monolithic `src/shaders.js`).
- `src/shaders/shared.js`: `getRegionPhysics()` referenced a global `params` uniform that only the compute shader (`spark-compute.js`) declares. `fiber.js` and `surface.js` include the same shared `HELPERS` block but bind their uniforms as `uniforms`, not `params`, so compilation failed with `unresolved value 'params'`. `getRegionPhysics` now takes `neuroPhysics`/`neuroRetention` as explicit parameters instead of reading a global — `fiber.js`/`surface.js` pass the original hardcoded defaults (`decay=0.96, diffusion=0.1`, full per-region override), and `spark-compute.js` passes its own `params` fields through unchanged, preserving its existing behavior.

## Test plan
- [x] `npm run build` succeeds
- [x] Confirmed no other reserved-word (`meta`) or unbound `params.` references remain in the WebGPU shader sources
- [x] Confirmed the WebGL2 fallback shaders (GLSL) are unaffected — this bug is specific to the WebGPU/WGSL path
- [ ] Manual visual check in a WebGPU browser (Chrome 113+) not run in this sandboxed environment

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013ke3bXxgyXdbPqV3YS2qCS

---
_Generated by [Claude Code](https://claude.ai/code/session_013ke3bXxgyXdbPqV3YS2qCS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regional signal-flow and neural simulation behavior.
  * Corrected how regional decay, diffusion, and flow-bias calculations use explicit physics and retention settings.
  * Improved consistency across fiber, surface, and compute-based visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->