### PR TITLE
Fix ONNX Runtime asset 404s by setting Vite base for /brain-viz/ deploy

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,14 @@
 import { defineConfig } from 'vite';
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
+  // Deployed under test.1ink.us/brain-viz/ (see deploy.py). Without this,
+  // Vite emits all asset URLs (including the ONNX Runtime .mjs/.wasm
+  // dynamic imports in src/inference-engine.js) at host-root '/assets/'
+  // instead of '/brain-viz/assets/', 404ing them in production and
+  // forcing InferenceEngine to fall back to synthetic activations. Only
+  // applied to `build` — the dev server (and scripts/test_run.py,
+  // verification/verify_suite.py) still expect localhost:5173 root.
+  base: command === 'build' ? '/brain-viz/' : '/',
   server: {
     headers: {
       'Cross-Origin-Opener-Policy': 'same-origin',
@@ -17,4 +25,4 @@ export default defineConfig({
     // Do not inline WASM binaries — they are loaded at runtime by the Emscripten glue.
     assetsInlineLimit: 0
   }
-});
+}));


### PR DESCRIPTION
## Summary
- Observed on test.1ink.us/brain-viz/: `GET /assets/ort-wasm-simd-threaded.jsep-*.mjs` 404'd, `[InferenceEngine] Falling back to synthetic activations`.
- Root cause: `deploy.py` publishes the build to `test.1ink.us/brain-viz/`, but `vite.config.js` never set `base`, so Vite emitted every build asset URL (including the dynamically-imported ONNX Runtime `.mjs`/`.wasm` files referenced via `?url` imports in `src/inference-engine.js`) at host-root `/assets/` instead of `/brain-viz/assets/`.
- Fix: `vite.config.js` now sets `base: '/brain-viz/'`, but only for `vite build` (checked via the `command` arg to `defineConfig`) — the dev server keeps `base: '/'` so `http://localhost:5173` still serves at root for `scripts/test_run.py` and `verification/verify_suite.py`.

## Test plan
- [x] `npm run build` — verified `dist/index.html`, the JS bundle, and both ONNX Runtime asset URLs are correctly emitted under `/brain-viz/assets/...`
- [x] `npx vite` dev server still serves `/` and `/src/main.js` with HTTP 200 at root (unaffected by the build-only base)
- [x] `python3 scripts/test_run.py` passes ("Server running ok")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KG6nV6Caw8uqR2vHzyNm3X

---
_Generated by [Claude Code](https://claude.ai/code/session_01KG6nV6Caw8uqR2vHzyNm3X)_