### PR TITLE
feat: complete Phase 28 DMN to TPN handoff

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -40,6 +40,7 @@ For the current architecture and module responsibilities, see [`AGENTS.md`](../A
 | 25 | Live EEG / BCI Devices | Muse Classic/Athena Web Bluetooth, OpenBCI UDP/WebSocket bridge, calibrated band-power projection into the human 32³ tensor, editable channel mapping, `.nwbci` recording/replay, and BCI routine events |
 | 26 | WebXR Immersive Mode | WebGL2 stereo VR, routine-driven XR rig, controller/hand energy painting, lobe viewpoints, and optional tabletop AR |
 | 27 | Double Mirror Multimodal Sessions | Local-only synchronized 32³ tensor, webcam-thumbnail, microphone-feature, and note capture; strict `.nwsession` replay/scrubbing; descriptive occipital/audio correlation heatmap; aligned CSV export |
+| 28 | Cognitive Phenomenon | DMN to task-positive network (TPN) handoff transition |
 
 ## Open Items
 

--- a/src/mini-routines/part2.js
+++ b/src/mini-routines/part2.js
@@ -656,3 +656,21 @@ MINI_ROUTINES_PART2['%'] = [ // [Phase 2.5] Dynamic Particle Speed Modulation
     { time: 8.0, type: 'lerp', key: 'particleSpeed', path: [0.1, 1.0], duration: 4.0, ease: 'sineInOut' },
     { time: 12.0, type: 'text', message: 'ROUTINE COMPLETE', duration: 2.0 }
 ];
+
+MINI_ROUTINES_PART2['T'] = [ // [Phase 28] DMN to TPN Handoff
+    { time: 0.0, type: 'text', message: 'Entering Default Mode Network (Idle)...', duration: 2.0 },
+    { time: 0.0, type: 'style', value: 2 }, // Connectome
+    { time: 0.0, type: 'camera', target: 'overview', duration: 2.0 },
+    { time: 0.0, type: 'dmn', intensity: 1.0, duration: 4.0 },
+
+    { time: 5.0, type: 'text', message: 'Task-Positive Network Engaging...', duration: 2.0 },
+    { time: 5.0, type: 'camera', target: 'frontal-tour', duration: 4.0 },
+    { time: 5.0, type: 'dmn_to_tpn', phase: 'engage', duration: 3.0 },
+
+    { time: 10.0, type: 'text', message: 'Task Complete. Releasing TPN...', duration: 2.0 },
+    { time: 10.0, type: 'camera', target: 'isometric', duration: 3.0 },
+    { time: 10.0, type: 'dmn_to_tpn', phase: 'release', duration: 3.0 },
+
+    { time: 14.0, type: 'calm' },
+    { time: 14.0, type: 'style', value: 0 }
+];

--- a/src/routine-handlers/narrative-flow.js
+++ b/src/routine-handlers/narrative-flow.js
@@ -106,6 +106,35 @@ export function registerNarrativeFlowHandlers(handlers, player) {
             player.routine.splice(insertIdx, 0, ...revertEvents);
         }
     });
+    // [Phase 28] DMN to TPN Transition Handoff
+    handlers.set('dmn_to_tpn', (evt) => {
+        const intensity = evt.intensity || 1.0;
+        const duration = evt.duration || 3.0;
+        const phase = evt.phase || 'engage'; // 'engage' or 'release'
+        const ease = evt.ease || 'easeInOutSine';
+
+        if (phase === 'engage') {
+            // Fade out DMN hum, increase focus parameters
+            player.startLerp({ key: 'frequency', value: 8.0 * intensity, duration: duration, ease: ease });
+            player.startLerp({ key: 'amplitude', value: 1.5 * intensity, duration: duration, ease: ease });
+            player.startLerp({ key: 'flowSpeed', value: 6.0 * intensity, duration: duration, ease: ease });
+            player.startLerp({ key: 'colorShift', value: 0.5 * intensity, duration: duration, ease: ease });
+            player.startLerp({ key: 'sparkle', value: 0.8 * intensity, duration: duration, ease: ease });
+
+            // Light up Task-Positive regions (Dorsal Attention Network proxy)
+            player.executeEvent({ type: 'stimulus', target: 'frontal', intensity: 2.0 * intensity, duration: duration });
+            player.executeEvent({ type: 'stimulus', target: 'parietal', intensity: 2.0 * intensity, duration: duration });
+        } else if (phase === 'release') {
+            // Revert back to DMN idle state
+            player.startLerp({ key: 'frequency', value: 0.5 * intensity, duration: duration, ease: ease });
+            player.startLerp({ key: 'amplitude', value: 0.2 * intensity, duration: duration, ease: ease });
+            player.startLerp({ key: 'flowSpeed', value: 0.3 * intensity, duration: duration, ease: ease });
+            player.startLerp({ key: 'colorShift', value: -0.2 * intensity, duration: duration, ease: ease });
+            player.startLerp({ key: 'sparkle', value: 0.0, duration: duration, ease: ease });
+        }
+    });
+
+
 
     // [Phase 2] Oxytocin Burst
     handlers.set('oxytocin', (evt) => {

--- a/src/ui-legend-panel.js
+++ b/src/ui-legend-panel.js
@@ -95,6 +95,7 @@ export function setupLegendPanel() {
             <div class="legend-row">
                 <div class="legend-item"><span class="legend-key">0</span><span>Focus</span></div>
                 <div class="legend-item"><span class="legend-key">-</span><span>Breathe</span></div>
+                <div class="legend-item"><span class="legend-key">T</span><span>DMN / TPN Switch</span></div>
                 <div class="legend-item"><span class="legend-key">l</span><span>Lighting</span></div>
                 <div class="legend-item"><span class="legend-key">g</span><span>Fog</span></div>
                 <div class="legend-item"><span class="legend-key">f</span><span>Filters</span></div>

--- a/verification/verify_routine.py
+++ b/verification/verify_routine.py
@@ -57,6 +57,14 @@ def verify() -> None:
             if overlay_visible:
                 raise AssertionError("Error overlay became visible")
 
+
+            # DMN to TPN Handoff routine
+            page.keyboard.press("T")
+            page.wait_for_timeout(10500) # wait past the 'engage' phase
+            page.screenshot(path=str(output_dir / "routine_tpn_engage.png"))
+            page.wait_for_timeout(4500) # wait through 'release' phase
+            page.screenshot(path=str(output_dir / "routine_tpn_release.png"))
+
             # Heartbeat routine
             page.keyboard.press("h")
             page.wait_for_timeout(3500)


### PR DESCRIPTION
This commit implements the Phase 28 feature: transitioning from the Default Mode Network (DMN) to a task-positive network (TPN) and back. It adds the `dmn_to_tpn` handler in `src/routine-handlers/narrative-flow.js`, a demonstration mini-routine bound to key `T`, an entry in the UI legend, and automated Playwright verification logic. It also correctly leaves `agent_plan.md` as history and adds the feature to the Completed Phases section in `docs/ROADMAP.md`.

---
*PR created automatically by Jules for task [4052355630719405044](https://jules.google.com/task/4052355630719405044) started by @ford442*